### PR TITLE
feat chat-create-001 메세지를 보냄으로써 채팅방 생성

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,9 @@ dependencies {
     annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
     annotationProcessor "jakarta.annotation:jakarta.annotation-api"
     annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
+    //websocket
+    implementation 'org.springframework.boot:spring-boot-starter-websocket'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/simzoo/withmedical/config/WebConfig.java
+++ b/src/main/java/com/simzoo/withmedical/config/WebConfig.java
@@ -1,0 +1,20 @@
+package com.simzoo.withmedical.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**")
+            .allowedOrigins("http://localhost:3000, http://localhost:3001, http://localhost:3002,")  // 프론트엔드 주소
+            .allowedMethods("*")  // 허용할 HTTP 메서드
+            .allowedHeaders("*")  // 모든 헤더 허용
+            .allowCredentials(true)  // 쿠키 허용 (필요할 경우)
+            .maxAge(3600);  // Preflight 요청 캐시 시간 설정 (1시간)
+    }
+
+}

--- a/src/main/java/com/simzoo/withmedical/config/WebSocketBrokerConfig.java
+++ b/src/main/java/com/simzoo/withmedical/config/WebSocketBrokerConfig.java
@@ -1,0 +1,34 @@
+package com.simzoo.withmedical.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+@Configuration
+@EnableWebSocketMessageBroker
+public class WebSocketBrokerConfig implements WebSocketMessageBrokerConfigurer {
+
+    //STOMP 엔드포인트 설정
+    @Override
+    public void registerStompEndpoints(StompEndpointRegistry registry) {
+        registry.addEndpoint("/ws-stomp")
+            .setAllowedOriginPatterns("*")
+            .withSockJS();
+    }
+
+    //메세지 브로커 설정
+    @Override
+    public void configureMessageBroker(MessageBrokerRegistry registry) {
+        // "/topic"으로 시작하는 메시지가 브로커로 라우팅됨 (/queue는 1:1, /topic은 1:N에서 주로 사용)
+        registry.enableSimpleBroker("/topic", "/queue");
+
+        // 클라이언트에서 서버로 메시지를 보낼 때 붙여야 하는 prefix(바로 브로커로 x)
+        registry.setApplicationDestinationPrefixes("/app");
+    }
+
+
+
+
+}

--- a/src/main/java/com/simzoo/withmedical/controller/ChatController.java
+++ b/src/main/java/com/simzoo/withmedical/controller/ChatController.java
@@ -1,0 +1,57 @@
+package com.simzoo.withmedical.controller;
+
+import com.simzoo.withmedical.dto.ChatMessageResponseDto;
+import com.simzoo.withmedical.dto.ChatStartRequestDto;
+import com.simzoo.withmedical.dto.ChatMessageRequestDto;
+import com.simzoo.withmedical.service.ChatService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.messaging.handler.annotation.DestinationVariable;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@Controller
+@RequiredArgsConstructor
+public class ChatController {
+
+    private final SimpMessagingTemplate simpMessagingTemplate;
+    private final ChatService chatService;
+
+    @PostMapping("/chat/start")
+    public ResponseEntity<?> startChat(@RequestBody ChatStartRequestDto requestDto) {
+
+        return ResponseEntity.ok(
+            chatService.createChatRoom(requestDto.getMember1Id(), requestDto.getMember2Id()).getId());
+    }
+
+    @PostMapping("/chat/{roomId}")
+    public ResponseEntity<?> sendMessage(@PathVariable Long roomId, @RequestBody ChatMessageRequestDto requestDto) {
+        // 메시지 저장 처리
+        ChatMessageResponseDto chatMessage = chatService.sendMessage(roomId, requestDto.getSenderId(),
+            requestDto.getRecipientId(), requestDto.getMessage()).toResponseDto();
+
+        // 메시지 브로커로 메시지 전송
+        simpMessagingTemplate.convertAndSend("/topic/chat/" + roomId, chatMessage);
+
+        return ResponseEntity.ok("Message sent successfully");
+    }
+
+    @MessageMapping("/chat/{roomId}") //클라이언트가 "/app/chat"으로 보낸 메세지 처리
+    public void processMessage(@DestinationVariable Long roomId, ChatMessageRequestDto requestDto) {
+
+        //메세지 저장
+        ChatMessageResponseDto chatMessage = chatService.sendMessage(roomId, requestDto.getSenderId(),
+            requestDto.getRecipientId(), requestDto.getMessage()).toResponseDto();
+
+        simpMessagingTemplate.convertAndSend("/topic/chat/" + roomId, chatMessage);
+    }
+
+    //특정 사용자에게 보내기
+    public void sendPrivateMessage(String userId, String message) {
+        simpMessagingTemplate.convertAndSendToUser(userId, "/queue/reply", message);
+    }
+}

--- a/src/main/java/com/simzoo/withmedical/dto/ChatMessageRequestDto.java
+++ b/src/main/java/com/simzoo/withmedical/dto/ChatMessageRequestDto.java
@@ -1,0 +1,18 @@
+package com.simzoo.withmedical.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class ChatMessageRequestDto {
+    private Long senderId;
+    private Long recipientId;
+    private String message;
+}

--- a/src/main/java/com/simzoo/withmedical/dto/ChatMessageResponseDto.java
+++ b/src/main/java/com/simzoo/withmedical/dto/ChatMessageResponseDto.java
@@ -1,0 +1,21 @@
+package com.simzoo.withmedical.dto;
+
+import com.simzoo.withmedical.enums.Role;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class ChatMessageResponseDto {
+    Long senderId;
+    Long recipientId;
+    String senderNickname;
+    String recipientNickname;
+    Role senderRole;
+    Role recipientRole;
+    String message;
+}

--- a/src/main/java/com/simzoo/withmedical/dto/ChatStartRequestDto.java
+++ b/src/main/java/com/simzoo/withmedical/dto/ChatStartRequestDto.java
@@ -1,0 +1,17 @@
+package com.simzoo.withmedical.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Setter
+public class ChatStartRequestDto {
+    private Long member1Id;
+    private Long member2Id;
+}

--- a/src/main/java/com/simzoo/withmedical/dto/TuteePostingSimpleResponseDto.java
+++ b/src/main/java/com/simzoo/withmedical/dto/TuteePostingSimpleResponseDto.java
@@ -13,6 +13,7 @@ import lombok.NoArgsConstructor;
 @Builder
 public class TuteePostingSimpleResponseDto {
     private Long postingId;
+    private Long memberId;
     private TuteeGrade studentGrade;
     private String studentSchool;
     private String personality;

--- a/src/main/java/com/simzoo/withmedical/entity/ChatMessageEntity.java
+++ b/src/main/java/com/simzoo/withmedical/entity/ChatMessageEntity.java
@@ -1,0 +1,53 @@
+package com.simzoo.withmedical.entity;
+
+import com.simzoo.withmedical.dto.ChatMessageResponseDto;
+import com.simzoo.withmedical.enums.MessageType;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+import org.hibernate.envers.AuditOverride;
+
+@Entity(name = "chatMessage")
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@SuperBuilder
+@AuditOverride(forClass = BaseEntity.class)
+public class ChatMessageEntity extends BaseEntity{
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private MemberEntity sender;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private MemberEntity recipient;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private ChatRoomEntity chatRoom;
+
+    private String message;
+
+    private MessageType messageType;
+
+    public ChatMessageResponseDto toResponseDto() {
+        return ChatMessageResponseDto.builder()
+            .senderId(sender.getId())
+            .recipientId(recipient.getId())
+            .message(message)
+            .senderNickname(sender.getNickname())
+            .recipientNickname(recipient.getNickname())
+            .senderRole(sender.getRole())
+            .recipientRole(recipient.getRole())
+            .build();
+    }
+}

--- a/src/main/java/com/simzoo/withmedical/entity/ChatRoomEntity.java
+++ b/src/main/java/com/simzoo/withmedical/entity/ChatRoomEntity.java
@@ -1,0 +1,33 @@
+package com.simzoo.withmedical.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+import org.hibernate.envers.AuditOverride;
+
+@Entity(name = "chatRoom")
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@SuperBuilder
+@AuditOverride(forClass = BaseEntity.class)
+public class ChatRoomEntity extends BaseEntity{
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String title;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private MemberEntity participant1;
+    @ManyToOne(fetch = FetchType.LAZY)
+    private MemberEntity participant2;
+}

--- a/src/main/java/com/simzoo/withmedical/entity/MemberEntity.java
+++ b/src/main/java/com/simzoo/withmedical/entity/MemberEntity.java
@@ -32,6 +32,7 @@ public class MemberEntity extends BaseEntity{
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    private String nickname;
     @Enumerated(EnumType.STRING)
     private Gender gender;
     private String phoneNumber;

--- a/src/main/java/com/simzoo/withmedical/entity/TuteePostEntity.java
+++ b/src/main/java/com/simzoo/withmedical/entity/TuteePostEntity.java
@@ -12,6 +12,7 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -32,7 +33,9 @@ public class TuteePostEntity extends BaseEntity {
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "memberId")
     private MemberEntity member;
+    @Enumerated(EnumType.STRING)
     private TuteeGrade grade;
     private Long tuteeId;
     private String description;
@@ -63,6 +66,7 @@ public class TuteePostEntity extends BaseEntity {
     public TuteePostingSimpleResponseDto toSimpleResponseDto() {
         return TuteePostingSimpleResponseDto.builder()
             .postingId(this.id)
+            .memberId(this.member.getId())
             .studentGrade(this.grade)
             .studentSchool(this.school)
             .personality(this.personality)

--- a/src/main/java/com/simzoo/withmedical/entity/TuteeProfileEntity.java
+++ b/src/main/java/com/simzoo/withmedical/entity/TuteeProfileEntity.java
@@ -43,8 +43,9 @@ public class TuteeProfileEntity extends BaseEntity {
     private Location location;
 
     @ElementCollection(fetch = FetchType.LAZY)
-    @CollectionTable(name = "tutee_subjects", joinColumns = @JoinColumn(name = "tuteeProfileId"))
+    @CollectionTable(name = "tuteeSubjects", joinColumns = @JoinColumn(name = "tuteeProfileId"))
     @Column(name = "subjectsNeeded")
+    @Enumerated(EnumType.STRING)
     private List<Subject> subjectsNeeded = new ArrayList<>();
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/com/simzoo/withmedical/entity/TutorProfileEntity.java
+++ b/src/main/java/com/simzoo/withmedical/entity/TutorProfileEntity.java
@@ -41,8 +41,9 @@ public class TutorProfileEntity extends BaseEntity{
     private MemberEntity member;
 
     @ElementCollection(fetch = FetchType.LAZY)
-    @CollectionTable(name = "tutor_subjects", joinColumns = @JoinColumn(name = "tutorProfileId"))
+    @CollectionTable(name = "tutorSubjects", joinColumns = @JoinColumn(name = "tutorProfileId"))
     @Column(name = "subjects")
+    @Enumerated(EnumType.STRING)
     private List<Subject> subjects = new ArrayList<>();
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/com/simzoo/withmedical/enums/EnrollmentStatus.java
+++ b/src/main/java/com/simzoo/withmedical/enums/EnrollmentStatus.java
@@ -6,7 +6,7 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public enum EnrollmentStatus {
-    ENROLLLED("재학"),
+    ENROLLED("재학"),
     LEAVE_OF_ABSENCE("휴학"),
     GRADUATED("졸업"),
     DROPPED_OUT("중퇴");

--- a/src/main/java/com/simzoo/withmedical/enums/MessageType.java
+++ b/src/main/java/com/simzoo/withmedical/enums/MessageType.java
@@ -1,0 +1,11 @@
+package com.simzoo.withmedical.enums;
+
+import lombok.Getter;
+
+@Getter
+public enum MessageType {
+    TEXT,
+    IMAGE,
+    VIDEO,
+    FILE
+}

--- a/src/main/java/com/simzoo/withmedical/exception/ErrorCode.java
+++ b/src/main/java/com/simzoo/withmedical/exception/ErrorCode.java
@@ -8,7 +8,8 @@ import org.springframework.http.HttpStatus;
 @Getter
 public enum ErrorCode {
     NOT_FOUND_USER(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),
-    NOT_FOUND_POSTING(HttpStatus.NOT_FOUND, "게시물을 찾을 수 없습니다.");
+    NOT_FOUND_POSTING(HttpStatus.NOT_FOUND, "게시물을 찾을 수 없습니다."),
+    NOT_FOUND_CHATROOM(HttpStatus.NOT_FOUND, "채팅방을 찾을 수 없습니다.");
 
     private HttpStatus httpStatus;
     private String message;

--- a/src/main/java/com/simzoo/withmedical/repository/ChatMessageRepository.java
+++ b/src/main/java/com/simzoo/withmedical/repository/ChatMessageRepository.java
@@ -1,0 +1,10 @@
+package com.simzoo.withmedical.repository;
+
+import com.simzoo.withmedical.entity.ChatMessageEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ChatMessageRepository extends JpaRepository<ChatMessageEntity, Long> {
+
+}

--- a/src/main/java/com/simzoo/withmedical/repository/ChatRoomRepository.java
+++ b/src/main/java/com/simzoo/withmedical/repository/ChatRoomRepository.java
@@ -1,0 +1,10 @@
+package com.simzoo.withmedical.repository;
+
+import com.simzoo.withmedical.entity.ChatRoomEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ChatRoomRepository extends JpaRepository<ChatRoomEntity, Long> {
+
+}

--- a/src/main/java/com/simzoo/withmedical/repository/MemberRepository.java
+++ b/src/main/java/com/simzoo/withmedical/repository/MemberRepository.java
@@ -1,10 +1,11 @@
 package com.simzoo.withmedical.repository;
 
 import com.simzoo.withmedical.entity.MemberEntity;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface MemberRepository extends JpaRepository<MemberEntity, Long> {
-
+    List<MemberEntity> findAllById(Iterable<Long> ids);
 }

--- a/src/main/java/com/simzoo/withmedical/service/ChatService.java
+++ b/src/main/java/com/simzoo/withmedical/service/ChatService.java
@@ -1,0 +1,75 @@
+package com.simzoo.withmedical.service;
+
+import com.simzoo.withmedical.entity.ChatMessageEntity;
+import com.simzoo.withmedical.entity.ChatRoomEntity;
+import com.simzoo.withmedical.entity.MemberEntity;
+import com.simzoo.withmedical.exception.CustomException;
+import com.simzoo.withmedical.exception.ErrorCode;
+import com.simzoo.withmedical.repository.ChatMessageRepository;
+import com.simzoo.withmedical.repository.ChatRoomRepository;
+import com.simzoo.withmedical.repository.MemberRepository;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ChatService {
+
+    private final ChatRoomRepository chatRoomRepository;
+    private final ChatMessageRepository chatMessageRepository;
+    private final MemberRepository memberRepository;
+
+    @Transactional
+    public ChatRoomEntity createChatRoom(Long id1, Long id2) {
+        Set<Long> memberIds = new HashSet<>(List.of(id1, id2));
+        Map<Long, MemberEntity> members = memberRepository.findAllById(memberIds).stream()
+            .collect(Collectors.toMap(MemberEntity::getId, memberEntity -> memberEntity));
+
+        MemberEntity participant1 = members.get(id1);
+        MemberEntity participant2 = members.get(id2);
+
+        String title = String.format("%s(%s)와 %s(%s)의 대화",
+            participant1.getNickname(),
+            participant1.getRole().name(),
+            participant2.getNickname(),
+            participant2.getRole().name()
+        );
+
+        ChatRoomEntity chatRoomEntity = ChatRoomEntity.builder()
+            .participant1(participant1)
+            .participant2(participant2)
+            .title(title)
+            .build();
+        return chatRoomRepository.save(chatRoomEntity);
+    }
+
+    @Transactional
+    public ChatMessageEntity sendMessage(Long roomId, Long senderId, Long recipientId,
+        String messageContent) {
+
+        Set<Long> memberIds = new HashSet<>(List.of(senderId, recipientId));
+        Map<Long, MemberEntity> members = memberRepository.findAllById(memberIds).stream()
+            .collect(Collectors.toMap(MemberEntity::getId, memberEntity -> memberEntity));
+
+        MemberEntity sender = members.get(senderId);
+        MemberEntity recipient = members.get(recipientId);
+
+        ChatRoomEntity chatRoomEntity = chatRoomRepository.findById(roomId)
+            .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_CHATROOM));
+
+        ChatMessageEntity chatMessage = ChatMessageEntity.builder()
+            .sender(sender)
+            .recipient(recipient)
+            .message(messageContent)
+            .chatRoom(chatRoomEntity)
+            .build();
+
+        return chatMessageRepository.save(chatMessage);
+    }
+}

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,0 +1,32 @@
+-- 첫 번째 회원(Member 1: 튜티)
+INSERT INTO member (nickname, gender, phoneNumber, password, passwordConfirm, role, createdAt, updatedAt)
+VALUES ('member1_nickname', 'MALE', '010-1234-5678', 'password123', 'password123', 'TUTEE', NOW(), NOW());
+
+-- 두 번째 회원(Member 2: 튜터)
+INSERT INTO member (nickname, gender, phoneNumber, password, passwordConfirm, role, createdAt, updatedAt)
+VALUES ('member2_nickname', 'FEMALE', '010-9876-5432', 'password456', 'password456', 'TUTOR', NOW(), NOW());
+
+-- 튜터 프로필 생성
+INSERT INTO tutorProfile (memberId, location, university, status, createdAt, updatedAt)
+VALUES ((SELECT id FROM member WHERE nickname = 'member2_nickname'), 'SEOUL', 'SEOUL_UNIVERSITY', 'ENROLLED', NOW(), NOW());
+
+-- 튜터가 가르치는 과목 추가 (예: 수학, 과학)
+INSERT INTO tutorSubjects (tutorProfileId, subjects)
+VALUES ((SELECT id FROM tutorProfile WHERE memberId = (SELECT id FROM member WHERE nickname = 'member2_nickname')), 'MIDDLE_MATH'),
+       ((SELECT id FROM tutorProfile WHERE memberId = (SELECT id FROM member WHERE nickname = 'member2_nickname')), 'MIDDLE_ENGLISH');
+
+-- 튜티 프로필 생성
+INSERT INTO tuteeProfile (memberId, location, grade, description, createdAt, updatedAt)
+VALUES ((SELECT id FROM member WHERE nickname = 'member1_nickname'), 'BUSAN', 'HIGH_1', 'Looking for a tutor in math and science.', NOW(), NOW());
+
+-- 튜티가 필요한 과목 추가 (예: 수학, 과학)
+INSERT INTO tuteeSubjects (tuteeProfileId, subjectsNeeded)
+VALUES ((SELECT id FROM tuteeProfile WHERE memberId = (SELECT id FROM member WHERE nickname = 'member1_nickname')), 'MIDDLE_MATH'),
+       ((SELECT id FROM tuteeProfile WHERE memberId = (SELECT id FROM member WHERE nickname = 'member1_nickname')), 'MIDDLE_ENGLISH');
+
+
+
+-- 첫 번째 게시물 (튜티 게시물) 삽입
+INSERT INTO tuteePost (memberId, grade, tuteeId, description, school, personality, type, possibleSchedule, level, fee, createdAt, updatedAt)
+VALUES
+    (1, 'HIGH_1', 1, '수학 과외를 받고 싶습니다. 주 2회, 1시간씩 진행했으면 좋겠습니다.', '서울고등학교', '적극적', 'ON_LINE', '월, 수 오후 4시 이후', '중급', 60, NOW(), NOW());


### PR DESCRIPTION
### 이 PR을 통해 해결하려는 문제
- 채팅방을 생성하여 데이터베이스에 저장한다. 
- 채팅 메세지 전송 시 메세지 데이터가 데이터베이스에 저장된다.

### 이 PR에서 변경된 사항
- WebSocket(+STOMP) 프로토콜 설정
  - build.gradle
  - WebSocketBrokerConfig
- ChatController
  - 채팅방 관리 컨트롤러 클래스
  - 채팅방 생성, 메세지 전송 기능 구현
- ChatService
  - 채팅방 생성 비즈니스로직 구현
  - 채팅 메세지 전송 비즈니스로직 구현
- ChatRoomRepository, ChatMessageRepository
  - 채팅방, 채팅메세지 관련 영속성 컨텍스트 클래스
- Entity
  - ChatRoomEntity
  - ChatMessageEntity
- Dto
  - ChatMessageRequestDto
  - ChatMessageResponseDto -CORS 설정
  - WebConfig

### 참고 스크린샷

### 기타
- 기타 수정사항
  - enum 타입 필드에 EnumType.STRING 설정 (MemberEntity, TuteePostEntity, TuteeProfileEntity, TutorProfileEntity)
  - TuteePostingSimpleResponseDto에서 memberId를 추가하여 프론트엔드에서 사용할 수 있도록 함
  - data.sql : 테스트 시 사용할 스크립트
  - React.js 연동하여 테스트 진행 중(message 전송까지 확인)
  
### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 -->
- [ ] 테스트 코드
- [x] API 테스트

