### PR TITLE
feat review-CRUD-001 리뷰 생성, 수정, 조회, 삭제 api

### DIFF
--- a/backend/src/main/java/com/simzoo/withmedical/controller/ReviewController.java
+++ b/backend/src/main/java/com/simzoo/withmedical/controller/ReviewController.java
@@ -1,0 +1,70 @@
+package com.simzoo.withmedical.controller;
+
+import com.simzoo.withmedical.dto.ReviewRequestDto;
+import com.simzoo.withmedical.dto.ReviewResponseDto;
+import com.simzoo.withmedical.dto.UpdateReviewRequestDto;
+import com.simzoo.withmedical.service.ReviewService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort.Direction;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/review")
+public class ReviewController {
+
+    private final ReviewService reviewService;
+
+    /**
+     * 리뷰 생성
+     */
+    //Todo 로그인 사용자 id 매개변수로 전달
+    @PostMapping
+    public ResponseEntity<ReviewResponseDto> createReview(Long userId,
+        @RequestBody ReviewRequestDto requestDto) {
+
+        return ResponseEntity.ok(reviewService.saveReview(userId, requestDto).toResponseDto());
+    }
+
+    /**
+     * 리뷰 수정
+     */
+    @PutMapping("/{reviewId}")
+    public ResponseEntity<ReviewResponseDto> updateReview(@PathVariable Long reviewId,
+        @RequestBody UpdateReviewRequestDto requestDto) {
+
+        return ResponseEntity.ok(reviewService.changeReview(reviewId, requestDto).toResponseDto());
+    }
+
+    /**
+     * 특정 튜터의 리뷰 조회
+     */
+    @GetMapping
+    public ResponseEntity<Page<ReviewResponseDto>> getTutorReviews(@RequestParam Long tutorId,
+        @PageableDefault(direction = Direction.DESC, sort = "createdAt") Pageable pageable) {
+
+        return ResponseEntity.ok(reviewService.getTutorReviews(tutorId, pageable));
+    }
+
+    /**
+     * 리뷰 삭제
+     */
+    @DeleteMapping({"reviewID"})
+    public ResponseEntity<Void> deleteReview(@PathVariable Long reviewId) {
+
+        reviewService.deleteReview(reviewId);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/backend/src/main/java/com/simzoo/withmedical/dto/ReviewRequestDto.java
+++ b/backend/src/main/java/com/simzoo/withmedical/dto/ReviewRequestDto.java
@@ -1,0 +1,31 @@
+package com.simzoo.withmedical.dto;
+
+import com.simzoo.withmedical.entity.MemberEntity;
+import com.simzoo.withmedical.entity.ReviewEntity;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class ReviewRequestDto {
+
+    private Long tutorProfileId;
+    private Double rating;
+    @Size(min = 1, max = 300)
+    private String reviewText;
+
+    public ReviewEntity toEntity(MemberEntity tutor, MemberEntity writer) {
+        return ReviewEntity.builder()
+            .tutorProfile(tutor.getTutorProfile())
+            .writer(writer)
+            .content(reviewText)
+            .rating(rating)
+            .build();
+    }
+
+}

--- a/backend/src/main/java/com/simzoo/withmedical/dto/ReviewResponseDto.java
+++ b/backend/src/main/java/com/simzoo/withmedical/dto/ReviewResponseDto.java
@@ -1,0 +1,30 @@
+package com.simzoo.withmedical.dto;
+
+import com.querydsl.core.annotations.QueryProjection;
+import java.time.LocalDateTime;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@Builder
+public class ReviewResponseDto {
+
+    private String tutorNickname;
+    private String writerNickname;
+    private Double rating;
+    private String reviewText;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+    @QueryProjection
+    public ReviewResponseDto(String tutorNickname, String writerNickname, Double rating, String reviewText, LocalDateTime createdAt, LocalDateTime updatedAt) {
+        this.tutorNickname = tutorNickname;
+        this.writerNickname = writerNickname;
+        this.rating = rating;
+        this.reviewText = reviewText;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+    }
+}

--- a/backend/src/main/java/com/simzoo/withmedical/dto/UpdateReviewRequestDto.java
+++ b/backend/src/main/java/com/simzoo/withmedical/dto/UpdateReviewRequestDto.java
@@ -1,0 +1,20 @@
+package com.simzoo.withmedical.dto;
+
+import com.simzoo.withmedical.entity.MemberEntity;
+import com.simzoo.withmedical.entity.ReviewEntity;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class UpdateReviewRequestDto {
+
+    private Double rating;
+    @Size(min = 1, max = 300)
+    private String reviewText;
+}

--- a/backend/src/main/java/com/simzoo/withmedical/entity/ReviewEntity.java
+++ b/backend/src/main/java/com/simzoo/withmedical/entity/ReviewEntity.java
@@ -1,9 +1,18 @@
 package com.simzoo.withmedical.entity;
 
+import com.simzoo.withmedical.dto.ReviewRequestDto;
+import com.simzoo.withmedical.dto.ReviewResponseDto;
+import com.simzoo.withmedical.dto.UpdateReviewRequestDto;
+import com.simzoo.withmedical.dto.UpdateTuteePostingRequestDto;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToOne;
+import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -22,7 +31,28 @@ public class ReviewEntity extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    private Long memberId;
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "memberId")
+    private MemberEntity writer;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "tutorProfileId")
+    private TutorProfileEntity tutorProfile;
     private String content;
-    private Integer rating;
+    private Double rating;
+
+    public ReviewResponseDto toResponseDto() {
+        return ReviewResponseDto.builder()
+            .writerNickname(writer.getNickname())
+            .tutorNickname(tutorProfile.getMember().getNickname())
+            .rating(rating)
+            .reviewText(content)
+            .createdAt(this.getCreatedAt())
+            .updatedAt(this.getUpdatedAt())
+            .build();
+    }
+
+    public void update(UpdateReviewRequestDto reviewRequestDto) {
+        this.rating = reviewRequestDto.getRating();
+        this.content = reviewRequestDto.getReviewText();
+    }
 }

--- a/backend/src/main/java/com/simzoo/withmedical/exception/ErrorCode.java
+++ b/backend/src/main/java/com/simzoo/withmedical/exception/ErrorCode.java
@@ -9,7 +9,8 @@ import org.springframework.http.HttpStatus;
 public enum ErrorCode {
     NOT_FOUND_USER(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),
     NOT_FOUND_POSTING(HttpStatus.NOT_FOUND, "게시물을 찾을 수 없습니다."),
-    NOT_FOUND_CHATROOM(HttpStatus.NOT_FOUND, "채팅방을 찾을 수 없습니다.");
+    NOT_FOUND_CHATROOM(HttpStatus.NOT_FOUND, "채팅방을 찾을 수 없습니다."),
+    NOT_FOUND_REVIEW(HttpStatus.NOT_FOUND, "리뷰를 찾을 수 없습니다.");
 
     private HttpStatus httpStatus;
     private String message;

--- a/backend/src/main/java/com/simzoo/withmedical/repository/MemberRepository.java
+++ b/backend/src/main/java/com/simzoo/withmedical/repository/MemberRepository.java
@@ -2,10 +2,14 @@ package com.simzoo.withmedical.repository;
 
 import com.simzoo.withmedical.entity.MemberEntity;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface MemberRepository extends JpaRepository<MemberEntity, Long> {
     List<MemberEntity> findAllById(Iterable<Long> ids);
+
+    Optional<MemberEntity> findByTutorProfile_Id(Long tutorProfileId);
+
 }

--- a/backend/src/main/java/com/simzoo/withmedical/repository/review/ReviewRepository.java
+++ b/backend/src/main/java/com/simzoo/withmedical/repository/review/ReviewRepository.java
@@ -1,0 +1,10 @@
+package com.simzoo.withmedical.repository.review;
+
+import com.simzoo.withmedical.entity.ReviewEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ReviewRepository extends JpaRepository<ReviewEntity, Long>, ReviewRepositoryCustom {
+
+}

--- a/backend/src/main/java/com/simzoo/withmedical/repository/review/ReviewRepositoryCustom.java
+++ b/backend/src/main/java/com/simzoo/withmedical/repository/review/ReviewRepositoryCustom.java
@@ -1,0 +1,9 @@
+package com.simzoo.withmedical.repository.review;
+
+import com.simzoo.withmedical.dto.ReviewResponseDto;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface ReviewRepositoryCustom {
+    Page<ReviewResponseDto> findReviewsByTutorId(Long tutorId, Pageable pageable);
+}

--- a/backend/src/main/java/com/simzoo/withmedical/repository/review/ReviewRepositoryCustomImpl.java
+++ b/backend/src/main/java/com/simzoo/withmedical/repository/review/ReviewRepositoryCustomImpl.java
@@ -1,0 +1,43 @@
+package com.simzoo.withmedical.repository.review;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.simzoo.withmedical.dto.QReviewResponseDto;
+import com.simzoo.withmedical.dto.ReviewResponseDto;
+import com.simzoo.withmedical.entity.QReviewEntity;
+import com.simzoo.withmedical.util.OrderSpecifierUtil;
+import java.util.List;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
+public class ReviewRepositoryCustomImpl implements ReviewRepositoryCustom{
+
+    JPAQueryFactory queryFactory;
+
+    @Override
+    public Page<ReviewResponseDto> findReviewsByTutorId(Long tutorId, Pageable pageable) {
+
+        QReviewEntity review = QReviewEntity.reviewEntity;
+
+        Long total = queryFactory.select(review.count())
+            .from(review)
+            .where(review.tutorProfile.id.eq(tutorId))
+            .fetchOne();
+
+        List<ReviewResponseDto> reviews = queryFactory.select(new QReviewResponseDto(
+            review.tutorProfile.member.nickname,
+            review.writer.nickname,
+            review.rating,
+            review.content,
+            review.createdAt,
+            review.updatedAt))
+            .from(review)
+            .where(review.tutorProfile.id.eq(tutorId))
+            .orderBy(OrderSpecifierUtil.getAllOrderSpecifiers(pageable, "reviewEntity"))
+            .offset(pageable.getOffset())
+            .limit(pageable.getPageSize())
+            .fetch();
+
+        return new PageImpl<>(reviews, pageable, total);
+    }
+}

--- a/backend/src/main/java/com/simzoo/withmedical/service/ReviewService.java
+++ b/backend/src/main/java/com/simzoo/withmedical/service/ReviewService.java
@@ -1,0 +1,65 @@
+package com.simzoo.withmedical.service;
+
+import com.simzoo.withmedical.dto.ReviewRequestDto;
+import com.simzoo.withmedical.dto.ReviewResponseDto;
+import com.simzoo.withmedical.dto.UpdateReviewRequestDto;
+import com.simzoo.withmedical.entity.MemberEntity;
+import com.simzoo.withmedical.entity.ReviewEntity;
+import com.simzoo.withmedical.exception.CustomException;
+import com.simzoo.withmedical.exception.ErrorCode;
+import com.simzoo.withmedical.repository.MemberRepository;
+import com.simzoo.withmedical.repository.review.ReviewRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ReviewService {
+
+    private final ReviewRepository reviewRepository;
+    private final MemberRepository memberRepository;
+
+    @Transactional
+    public ReviewEntity saveReview(Long userId, ReviewRequestDto requestDto) {
+
+        MemberEntity tutor = memberRepository.findByTutorProfile_Id(
+            requestDto.getTutorProfileId()).orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_USER));
+
+        MemberEntity writer = memberRepository.findById(
+            requestDto.getTutorProfileId()).orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_USER));
+
+
+        return reviewRepository.save(requestDto.toEntity(tutor, writer));
+    }
+
+    @Transactional
+    public ReviewEntity changeReview(Long reviewId, UpdateReviewRequestDto requestDto) {
+
+        ReviewEntity reviewEntity = reviewRepository.findById(reviewId)
+            .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_REVIEW));
+
+        reviewEntity.update(requestDto);
+
+        return reviewEntity;
+    }
+
+    @Transactional(readOnly = true)
+    public Page<ReviewResponseDto> getTutorReviews(Long tutorId, Pageable pageable) {
+
+        return reviewRepository.findReviewsByTutorId(tutorId, pageable);
+    }
+
+    /**
+     * 리뷰 삭제
+     */
+    @Transactional
+    public void deleteReview(Long reviewId) {
+        ReviewEntity reviewEntity = reviewRepository.findById(reviewId)
+            .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_REVIEW));
+
+        reviewRepository.delete(reviewEntity);
+    }
+}

--- a/backend/src/main/java/com/simzoo/withmedical/util/OrderSpecifierUtil.java
+++ b/backend/src/main/java/com/simzoo/withmedical/util/OrderSpecifierUtil.java
@@ -7,6 +7,7 @@ import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.core.types.dsl.PathBuilder;
 import com.simzoo.withmedical.entity.QChatMessageEntity;
 import com.simzoo.withmedical.entity.QChatRoomEntity;
+import com.simzoo.withmedical.entity.QReviewEntity;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -23,6 +24,7 @@ public class OrderSpecifierUtil {
     static {
         ENTITY_PATH_MAP.put("chatRoomEntity", new PathBuilder<>(QChatRoomEntity.class, "chatRoomEntity"));
         ENTITY_PATH_MAP.put("chatMessageEntity", new PathBuilder<>(QChatMessageEntity.class, "chatMessageEntity"));
+        ENTITY_PATH_MAP.put("reviewEntity", new PathBuilder<>(QReviewEntity.class, "reviewEntity"));
         // 새로운 엔티티가 추가될 때마다 여기에 추가
     }
 


### PR DESCRIPTION
### 이 PR을 통해 해결하려는 문제
- 튜터에 대한 리뷰 작성, 수정, 조회, 삭제 기능 구현

### 이 PR에서 변경된 사항
- ReviewEntity 수정 : 
  - writer, tutorProfile 객체를 필드 추가 
  - toResponseDto() 생성 : 
  - update() 생성 
  - rating, content 만 수정

- Dto
  - ReviewResponseDto 
    - 생성, 수정 시 사용 : tutorNickname, writerNickname, rating, reviewText, createdAt, updatedAt 반환
  - ReviewRequestDto : toEntity() 생성
  - UpdateReviewRequestDto : reviewText, rating 수정 요청

- ReviewRepository, ReviewRepositoryCustom, ReviewRepositoryCustomImpl : 리뷰데이터 조회 시 queryDsl 사용하여 dto 로 조회할 수 있도록 작성


### 참고 스크린샷

### 기타

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 -->
- [ ] 테스트 코드
- [ ] API 테스트
