### PR TITLE
feat signup-001 회원가입(회원정보 저장)

### DIFF
--- a/backend/src/main/java/com/simzoo/withmedical/controller/SignupController.java
+++ b/backend/src/main/java/com/simzoo/withmedical/controller/SignupController.java
@@ -1,0 +1,26 @@
+package com.simzoo.withmedical.controller;
+
+import com.simzoo.withmedical.dto.MemberResponseDto;
+import com.simzoo.withmedical.dto.auth.SignupRequestDto;
+import com.simzoo.withmedical.service.SignupService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@Slf4j
+public class SignupController {
+
+    private final SignupService signupService;
+
+    @PostMapping("/signup")
+    public ResponseEntity<MemberResponseDto> signup(@RequestBody SignupRequestDto requestDto) {
+
+        return ResponseEntity.ok(signupService.signup(requestDto).toResponseDto());
+    }
+
+}

--- a/backend/src/main/java/com/simzoo/withmedical/dto/MemberResponseDto.java
+++ b/backend/src/main/java/com/simzoo/withmedical/dto/MemberResponseDto.java
@@ -1,0 +1,34 @@
+package com.simzoo.withmedical.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.simzoo.withmedical.entity.TuteeProfileEntity;
+import com.simzoo.withmedical.entity.TutorProfileEntity;
+import com.simzoo.withmedical.enums.Gender;
+import com.simzoo.withmedical.enums.Role;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Setter
+@JsonInclude(Include.NON_NULL)
+public class MemberResponseDto {
+    private Long id;
+    private String nickname;
+    private Gender gender;
+    private String phoneNumber;
+    private Role role;
+
+    private TutorProfileEntity tutorProfile;
+
+    private TuteeProfileEntity tuteeProfile;
+
+    private List<TuteeProfileEntity> tuteeProfiles;
+}

--- a/backend/src/main/java/com/simzoo/withmedical/dto/TuteeProfileRequestDto.java
+++ b/backend/src/main/java/com/simzoo/withmedical/dto/TuteeProfileRequestDto.java
@@ -1,0 +1,26 @@
+package com.simzoo.withmedical.dto;
+
+import com.simzoo.withmedical.entity.MemberEntity;
+import com.simzoo.withmedical.entity.TuteeProfileEntity;
+import com.simzoo.withmedical.enums.Location;
+import com.simzoo.withmedical.enums.Subject;
+import com.simzoo.withmedical.enums.TuteeGrade;
+import java.util.List;
+
+public class TuteeProfileRequestDto {
+
+    private Location location;
+    private List<Subject> subjects;
+    private String description;
+    private TuteeGrade tuteeGrade;
+
+    public TuteeProfileEntity toEntity(MemberEntity member) {
+        return TuteeProfileEntity.builder()
+            .location(location)
+            .description(description)
+            .subjectsNeeded(subjects)
+            .grade(tuteeGrade)
+            .member(member)
+            .build();
+    }
+}

--- a/backend/src/main/java/com/simzoo/withmedical/dto/TutorProfileRequestDto.java
+++ b/backend/src/main/java/com/simzoo/withmedical/dto/TutorProfileRequestDto.java
@@ -1,0 +1,31 @@
+package com.simzoo.withmedical.dto;
+
+import com.simzoo.withmedical.entity.MemberEntity;
+import com.simzoo.withmedical.entity.TutorProfileEntity;
+import com.simzoo.withmedical.enums.EnrollmentStatus;
+import com.simzoo.withmedical.enums.Location;
+import com.simzoo.withmedical.enums.Subject;
+import com.simzoo.withmedical.enums.University;
+import java.util.List;
+import org.springframework.web.multipart.MultipartFile;
+
+public class TutorProfileRequestDto {
+    private MultipartFile proofFile;
+    private MultipartFile profileImage;
+    private List<Subject> subjects;
+    private Location location;
+    private String description;
+    private University university;
+    private EnrollmentStatus status;
+
+    public TutorProfileEntity toEntity(MemberEntity member) {
+        return TutorProfileEntity.builder()
+            .subjects(subjects)
+            .location(location)
+            .description(description)
+            .university(university)
+            .status(status)
+            .member(member)
+            .build();
+    }
+}

--- a/backend/src/main/java/com/simzoo/withmedical/dto/auth/SignupRequestDto.java
+++ b/backend/src/main/java/com/simzoo/withmedical/dto/auth/SignupRequestDto.java
@@ -1,0 +1,63 @@
+package com.simzoo.withmedical.dto.auth;
+
+import com.simzoo.withmedical.dto.TuteeProfileRequestDto;
+import com.simzoo.withmedical.dto.TutorProfileRequestDto;
+import com.simzoo.withmedical.entity.MemberEntity;
+import com.simzoo.withmedical.enums.Gender;
+import com.simzoo.withmedical.enums.Role;
+import com.simzoo.withmedical.util.validator.Password;
+import com.simzoo.withmedical.util.validator.PasswordConfirm;
+import com.simzoo.withmedical.util.validator.PhoneNumber;
+import com.simzoo.withmedical.util.validator.ProfileNotNull;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@PasswordConfirm
+@ProfileNotNull
+public class SignupRequestDto {
+
+    @Size(min = 2, max = 20)
+    @NotBlank
+    private String nickname;
+
+    @NotNull
+    private Gender gender;
+
+    @NotBlank
+    @PhoneNumber
+    private String phoneNumber;
+
+    @Password
+    @NotBlank
+    private String password;
+    @NotBlank
+    private String passwordConfirm;
+    private Role role;
+
+    private TutorProfileRequestDto tutorProfile;
+    private TuteeProfileRequestDto tuteeProfile;
+    private List<TuteeProfileRequestDto> tuteeProfiles = new ArrayList<>();
+
+    public MemberEntity toMemberEntity() {
+        return MemberEntity.builder()
+            .nickname(nickname)
+            .gender(gender)
+            .phoneNumber(phoneNumber)
+            .password(password)
+            .role(role)
+            .build();
+    }
+
+
+}

--- a/backend/src/main/java/com/simzoo/withmedical/entity/MemberEntity.java
+++ b/backend/src/main/java/com/simzoo/withmedical/entity/MemberEntity.java
@@ -2,8 +2,11 @@ package com.simzoo.withmedical.entity;
 
 import static jakarta.persistence.FetchType.LAZY;
 
+import com.simzoo.withmedical.dto.MemberResponseDto;
 import com.simzoo.withmedical.enums.Gender;
 import com.simzoo.withmedical.enums.Role;
+import com.simzoo.withmedical.exception.CustomException;
+import com.simzoo.withmedical.exception.ErrorCode;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
@@ -40,10 +43,50 @@ public class MemberEntity extends BaseEntity{
     private String passwordConfirm;
     @Enumerated(EnumType.STRING)
     private Role role;
+
     @OneToOne(fetch = LAZY)
     @JoinColumn(name = "memberId")
     private TutorProfileEntity tutorProfile;
+
+    @OneToOne(fetch = LAZY)
+    @JoinColumn(name = "memberId")
+    private TuteeProfileEntity tuteeProfile;
+
     @OneToMany(fetch = LAZY)
     @JoinColumn(name = "memberId")
-    private List<TuteeProfileEntity> tuteeProfile;
+    private List<TuteeProfileEntity> tuteeProfiles;
+
+    public MemberResponseDto toResponseDto() {
+        return MemberResponseDto.builder()
+            .id(id)
+            .nickname(nickname)
+            .gender(gender)
+            .phoneNumber(phoneNumber)
+            .role(role)
+            .tutorProfile(tutorProfile)
+            .tuteeProfiles(tuteeProfiles)
+            .tuteeProfile(tuteeProfile)
+            .build();
+    }
+
+    public void saveTuteeProfile(TuteeProfileEntity profile) {
+        if (role == Role.TUTEE) {
+            throw new CustomException(ErrorCode.PROFILE_ROLE_NOT_MATCH);
+        }
+        this.tuteeProfile = profile;
+    }
+
+    public void saveTutorProfile(TutorProfileEntity profile) {
+        if (role == Role.TUTOR) {
+            throw new CustomException(ErrorCode.PROFILE_ROLE_NOT_MATCH);
+        }
+        this.tutorProfile = profile;
+    }
+
+    public void addTutorProfile(TuteeProfileEntity profile) {
+        if (role == Role.PARENT) {
+            throw new CustomException(ErrorCode.PROFILE_ROLE_NOT_MATCH);
+        }
+        this.tuteeProfiles.add(profile);
+    }
 }

--- a/backend/src/main/java/com/simzoo/withmedical/entity/TuteeProfileEntity.java
+++ b/backend/src/main/java/com/simzoo/withmedical/entity/TuteeProfileEntity.java
@@ -52,5 +52,4 @@ public class TuteeProfileEntity extends BaseEntity {
     private TuteeGrade grade;
 
     private String description;
-
 }

--- a/backend/src/main/java/com/simzoo/withmedical/entity/TutorProfileEntity.java
+++ b/backend/src/main/java/com/simzoo/withmedical/entity/TutorProfileEntity.java
@@ -30,7 +30,7 @@ import org.hibernate.envers.AuditOverride;
 @AllArgsConstructor
 @NoArgsConstructor
 @AuditOverride(forClass = BaseEntity.class)
-public class TutorProfileEntity extends BaseEntity{
+public class TutorProfileEntity extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -54,4 +54,6 @@ public class TutorProfileEntity extends BaseEntity{
 
     @Enumerated(EnumType.STRING)
     private EnrollmentStatus status;
+
+    private String description;
 }

--- a/backend/src/main/java/com/simzoo/withmedical/exception/ErrorCode.java
+++ b/backend/src/main/java/com/simzoo/withmedical/exception/ErrorCode.java
@@ -10,7 +10,10 @@ public enum ErrorCode {
     NOT_FOUND_USER(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),
     NOT_FOUND_POSTING(HttpStatus.NOT_FOUND, "게시물을 찾을 수 없습니다."),
     NOT_FOUND_CHATROOM(HttpStatus.NOT_FOUND, "채팅방을 찾을 수 없습니다."),
-    NOT_FOUND_REVIEW(HttpStatus.NOT_FOUND, "리뷰를 찾을 수 없습니다.");
+    NOT_FOUND_REVIEW(HttpStatus.NOT_FOUND, "리뷰를 찾을 수 없습니다."),
+    PROFILE_ROLE_NOT_MATCH(HttpStatus.BAD_REQUEST, "사용자의 역할과 프로필이 일치하지 않습니다."),
+    ALREADY_EXIST_MEMBER(HttpStatus.BAD_REQUEST, "이미 가입한 회원입니다.")
+    ;
 
     private HttpStatus httpStatus;
     private String message;

--- a/backend/src/main/java/com/simzoo/withmedical/repository/MemberRepository.java
+++ b/backend/src/main/java/com/simzoo/withmedical/repository/MemberRepository.java
@@ -12,4 +12,5 @@ public interface MemberRepository extends JpaRepository<MemberEntity, Long> {
 
     Optional<MemberEntity> findByTutorProfile_Id(Long tutorProfileId);
 
+    Optional<MemberEntity> findByPhoneNumber(String phoneNumber);
 }

--- a/backend/src/main/java/com/simzoo/withmedical/repository/TuteeProfileRepository.java
+++ b/backend/src/main/java/com/simzoo/withmedical/repository/TuteeProfileRepository.java
@@ -1,0 +1,10 @@
+package com.simzoo.withmedical.repository;
+
+import com.simzoo.withmedical.entity.TuteeProfileEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface TuteeProfileRepository extends JpaRepository<TuteeProfileEntity, Long> {
+
+}

--- a/backend/src/main/java/com/simzoo/withmedical/repository/TutorProfileRepository.java
+++ b/backend/src/main/java/com/simzoo/withmedical/repository/TutorProfileRepository.java
@@ -1,0 +1,10 @@
+package com.simzoo.withmedical.repository;
+
+import com.simzoo.withmedical.entity.TutorProfileEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface TutorProfileRepository extends JpaRepository<TutorProfileEntity, Long> {
+
+}

--- a/backend/src/main/java/com/simzoo/withmedical/service/SignupService.java
+++ b/backend/src/main/java/com/simzoo/withmedical/service/SignupService.java
@@ -1,0 +1,46 @@
+package com.simzoo.withmedical.service;
+
+import com.simzoo.withmedical.dto.auth.SignupRequestDto;
+import com.simzoo.withmedical.entity.MemberEntity;
+import com.simzoo.withmedical.enums.Role;
+import com.simzoo.withmedical.exception.CustomException;
+import com.simzoo.withmedical.exception.ErrorCode;
+import com.simzoo.withmedical.repository.MemberRepository;
+import com.simzoo.withmedical.repository.TuteeProfileRepository;
+import com.simzoo.withmedical.repository.TutorProfileRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class SignupService {
+
+    private final TutorProfileRepository tutorProfileRepository;
+    private final MemberRepository memberRepository;
+    private final TuteeProfileRepository tuteeProfileRepository;
+
+    @Transactional
+    public MemberEntity signup(SignupRequestDto requestDto) {
+        memberRepository.findByPhoneNumber(requestDto.getPhoneNumber()).ifPresent(e -> {
+            throw new CustomException(ErrorCode.ALREADY_EXIST_MEMBER);
+        });
+
+        MemberEntity member = memberRepository.save(requestDto.toMemberEntity());
+
+        if (member.getRole() == Role.TUTEE) {
+            member.saveTuteeProfile(
+                tuteeProfileRepository.save(requestDto.getTuteeProfile().toEntity(member)));
+        } else if (member.getRole() == Role.TUTOR) {
+            member.saveTutorProfile(
+                tutorProfileRepository.save(requestDto.getTutorProfile().toEntity(member)));
+        } else {
+            tuteeProfileRepository.saveAll(
+                requestDto.getTuteeProfiles().stream().map(e -> e.toEntity(member)).toList());
+        }
+
+        return member;
+    }
+
+
+}

--- a/backend/src/main/java/com/simzoo/withmedical/util/validator/Password.java
+++ b/backend/src/main/java/com/simzoo/withmedical/util/validator/Password.java
@@ -1,0 +1,22 @@
+package com.simzoo.withmedical.util.validator;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.FIELD)
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = {PasswordValidator.class})
+public @interface Password {
+
+    String regexp() default "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[@#$%^&+=!]).{8,50}$";
+
+    String message() default "비밀번호는 영문, 숫자, 특수문자를 포함하여 8 ~ 50자 이내여야 합니다.";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}

--- a/backend/src/main/java/com/simzoo/withmedical/util/validator/PasswordConfirm.java
+++ b/backend/src/main/java/com/simzoo/withmedical/util/validator/PasswordConfirm.java
@@ -1,0 +1,19 @@
+package com.simzoo.withmedical.util.validator;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = PasswordConfirmValidator.class)
+public @interface PasswordConfirm {
+
+    String message() default "비밀번호가 일치하지 않습니다.";
+
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+}

--- a/backend/src/main/java/com/simzoo/withmedical/util/validator/PasswordConfirmValidator.java
+++ b/backend/src/main/java/com/simzoo/withmedical/util/validator/PasswordConfirmValidator.java
@@ -1,0 +1,18 @@
+package com.simzoo.withmedical.util.validator;
+
+import com.simzoo.withmedical.dto.auth.SignupRequestDto;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+public class PasswordConfirmValidator implements ConstraintValidator<PasswordConfirm, SignupRequestDto> {
+
+    @Override
+    public void initialize(PasswordConfirm constraintAnnotation) {
+    }
+
+    @Override
+    public boolean isValid(SignupRequestDto signupRequestDto, ConstraintValidatorContext context) {
+
+        return signupRequestDto.getPassword().equals(signupRequestDto.getPasswordConfirm());
+    }
+}

--- a/backend/src/main/java/com/simzoo/withmedical/util/validator/PasswordValidator.java
+++ b/backend/src/main/java/com/simzoo/withmedical/util/validator/PasswordValidator.java
@@ -1,0 +1,20 @@
+package com.simzoo.withmedical.util.validator;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import java.util.regex.Pattern;
+
+public class PasswordValidator implements ConstraintValidator<Password, String> {
+
+    private String regexp;
+
+    @Override
+    public void initialize(Password constraintAnnotation) {
+        regexp = constraintAnnotation.regexp();
+    }
+
+    @Override
+    public boolean isValid(String value, ConstraintValidatorContext context) {
+        return Pattern.matches(regexp, value);
+    }
+}

--- a/backend/src/main/java/com/simzoo/withmedical/util/validator/PhoneNumber.java
+++ b/backend/src/main/java/com/simzoo/withmedical/util/validator/PhoneNumber.java
@@ -1,0 +1,20 @@
+package com.simzoo.withmedical.util.validator;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.FIELD)
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = {PhoneNumberValidator.class})
+public @interface PhoneNumber {
+    String message() default "핸드폰 번호 양식에 맞지 않습니다. ex) 010-0000-0000";
+    String regexp() default "^\\d{2,3}-\\d{3,4}-\\d{4}$";
+
+    Class<?>[] groups() default { };
+
+    Class<? extends Payload>[] payload() default { };
+}

--- a/backend/src/main/java/com/simzoo/withmedical/util/validator/PhoneNumberValidator.java
+++ b/backend/src/main/java/com/simzoo/withmedical/util/validator/PhoneNumberValidator.java
@@ -1,0 +1,20 @@
+package com.simzoo.withmedical.util.validator;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import java.util.regex.Pattern;
+
+public class PhoneNumberValidator implements ConstraintValidator<PhoneNumber, String> {
+
+    private String regex;
+
+    @Override
+    public void initialize(PhoneNumber constraintAnnotation) {
+        this.regex = constraintAnnotation.regexp();
+    }
+
+    @Override
+    public boolean isValid(String s, ConstraintValidatorContext constraintValidatorContext) {
+        return Pattern.matches(regex, s);
+    }
+}

--- a/backend/src/main/java/com/simzoo/withmedical/util/validator/ProfileNotNull.java
+++ b/backend/src/main/java/com/simzoo/withmedical/util/validator/ProfileNotNull.java
@@ -1,0 +1,20 @@
+package com.simzoo.withmedical.util.validator;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = ProfileNotNullValidator.class)
+public @interface ProfileNotNull {
+
+    String message() default "프로필 정보를 입력해주세요";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}

--- a/backend/src/main/java/com/simzoo/withmedical/util/validator/ProfileNotNullValidator.java
+++ b/backend/src/main/java/com/simzoo/withmedical/util/validator/ProfileNotNullValidator.java
@@ -1,0 +1,23 @@
+package com.simzoo.withmedical.util.validator;
+
+import com.simzoo.withmedical.dto.auth.SignupRequestDto;
+import com.simzoo.withmedical.enums.Role;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import java.util.Objects;
+
+public class ProfileNotNullValidator implements ConstraintValidator<ProfileNotNull, SignupRequestDto>{
+
+    @Override
+    public void initialize(ProfileNotNull constraintAnnotation) {
+    }
+
+    @Override
+    public boolean isValid(SignupRequestDto requestDto, ConstraintValidatorContext context) {
+        if (requestDto.getRole() == Role.TUTOR) {
+            return !Objects.isNull(requestDto.getTutorProfile());
+        } else {
+            return !Objects.isNull(requestDto.getTuteeProfile());
+        }
+    }
+}


### PR DESCRIPTION

### 이 PR을 통해 해결하려는 문제
- 회원가입을 요청했을 때 기존 가입 여부를 확인하고 회원 정보를 저장한다.
- 회원가입 시, 역할에 따라 각각의 프로필 정보를 저장한다.
- 로그인 아이디는 휴대전화번호를 사용한다. 

### 이 PR에서 변경된 사항
- 회원정보 저장 로직 구현
- Todo : 이미지 저장, 휴대전화번호 인증

- Validation
  - 비밀번호 검증 : Password, PasswordValidator, PasswordConfirm, PasswordConfirmValidator
  - 휴대전화 형식 검증 : PhoneNumber, PhoneNumberValidator
  - 역할에 맞는 프로파일설정 : ProfileNotNull, ProfileNotNullValidator

- Entity
  - MemberEntity
  - TutorProfileEntity
  - TuteeProfileEntity

- Dto
  - SignupRequestDto
  - MemberResponseDto
  - TutorProfileRequestDto
  - TuteeProfileRequestDto

### 참고 스크린샷

### 기타

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 -->
- [ ] 테스트 코드
- [ ] API 테스트
