### PR TITLE
feat auth-001 로그인 기능 구현

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -27,6 +27,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    testImplementation 'org.springframework.security:spring-security-test'
 
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.h2database:h2'
@@ -53,7 +54,11 @@ dependencies {
     //coolsms
     implementation 'net.nurigo:sdk:4.3.0'
 
-
+    //security
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
+    implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
 }
 
 tasks.named('test') {

--- a/backend/src/main/java/com/simzoo/withmedical/config/SecurityConfig.java
+++ b/backend/src/main/java/com/simzoo/withmedical/config/SecurityConfig.java
@@ -1,0 +1,67 @@
+package com.simzoo.withmedical.config;
+
+import com.simzoo.withmedical.security.CustomUserDetailsService;
+import com.simzoo.withmedical.security.JwtAuthenticationFilter;
+import com.simzoo.withmedical.util.JwtUtil;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@RequiredArgsConstructor
+@EnableWebSecurity
+public class SecurityConfig {
+
+    private final JwtUtil jwtUtil;
+    private final CustomUserDetailsService customUserDetailsService;
+
+    private static final List<String> PERMIT_ALL_URLS = List.of(
+        "/index.html",
+        "/css/**",
+        "/images/**",
+        "/js/**",
+        "/swagger-ui/*",
+        "v3/api-docs/**"
+    );
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+
+        http.
+            authorizeHttpRequests(
+                request -> request
+                    .requestMatchers(PERMIT_ALL_URLS.toArray(new String[0]))
+                    .permitAll()
+                    .anyRequest().authenticated()
+            )
+            .sessionManagement(
+                session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+            .addFilterBefore(jwtAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class)
+            .formLogin(AbstractHttpConfigurer::disable)
+            .logout(AbstractHttpConfigurer::disable)
+            .csrf(AbstractHttpConfigurer::disable);
+
+        return http.build();
+    }
+
+    @Bean
+    public JwtAuthenticationFilter jwtAuthenticationFilter() {
+        return new JwtAuthenticationFilter(jwtUtil);
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+
+}

--- a/backend/src/main/java/com/simzoo/withmedical/controller/AuthController.java
+++ b/backend/src/main/java/com/simzoo/withmedical/controller/AuthController.java
@@ -1,0 +1,24 @@
+package com.simzoo.withmedical.controller;
+
+import com.simzoo.withmedical.dto.auth.JwtResponseDto;
+import com.simzoo.withmedical.dto.auth.LoginRequestDto;
+import com.simzoo.withmedical.service.AuthService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@Slf4j
+public class AuthController {
+
+    private final AuthService authService;
+
+    @PostMapping("/login")
+    public ResponseEntity<JwtResponseDto> login(@RequestBody LoginRequestDto requestDto) {
+        return ResponseEntity.ok(authService.login(requestDto));
+    }
+}

--- a/backend/src/main/java/com/simzoo/withmedical/dto/MemberResponseDto.java
+++ b/backend/src/main/java/com/simzoo/withmedical/dto/MemberResponseDto.java
@@ -24,7 +24,7 @@ public class MemberResponseDto {
     private String nickname;
     private Gender gender;
     private String phoneNumber;
-    private Role role;
+    private List<Role> role;
 
     private TutorProfileEntity tutorProfile;
 

--- a/backend/src/main/java/com/simzoo/withmedical/dto/auth/JwtResponseDto.java
+++ b/backend/src/main/java/com/simzoo/withmedical/dto/auth/JwtResponseDto.java
@@ -1,0 +1,10 @@
+package com.simzoo.withmedical.dto.auth;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class JwtResponseDto {
+    private String accessToken;
+}

--- a/backend/src/main/java/com/simzoo/withmedical/dto/auth/LoginRequestDto.java
+++ b/backend/src/main/java/com/simzoo/withmedical/dto/auth/LoginRequestDto.java
@@ -1,0 +1,13 @@
+package com.simzoo.withmedical.dto.auth;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class LoginRequestDto {
+    private String phoneNumber;
+    private String password;
+}

--- a/backend/src/main/java/com/simzoo/withmedical/dto/auth/SignupRequestDto.java
+++ b/backend/src/main/java/com/simzoo/withmedical/dto/auth/SignupRequestDto.java
@@ -5,6 +5,7 @@ import com.simzoo.withmedical.dto.TutorProfileRequestDto;
 import com.simzoo.withmedical.entity.MemberEntity;
 import com.simzoo.withmedical.enums.Gender;
 import com.simzoo.withmedical.enums.Role;
+import com.simzoo.withmedical.util.AesUtil;
 import com.simzoo.withmedical.util.validator.Password;
 import com.simzoo.withmedical.util.validator.PasswordConfirm;
 import com.simzoo.withmedical.util.validator.PhoneNumber;
@@ -18,6 +19,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
 @Getter
 @Builder
@@ -49,13 +51,12 @@ public class SignupRequestDto {
     private TuteeProfileRequestDto tuteeProfile;
     private List<TuteeProfileRequestDto> tuteeProfiles = new ArrayList<>();
 
-    public MemberEntity toMemberEntity() {
+    public MemberEntity toMemberEntity(PasswordEncoder passwordEncoder) {
         return MemberEntity.builder()
             .nickname(nickname)
             .gender(gender)
-            .phoneNumber(phoneNumber)
-            .password(password)
-            .role(role)
+            .phoneNumber(AesUtil.decrypt(phoneNumber))
+            .password(passwordEncoder.encode(password))
             .build();
     }
 

--- a/backend/src/main/java/com/simzoo/withmedical/entity/MemberEntity.java
+++ b/backend/src/main/java/com/simzoo/withmedical/entity/MemberEntity.java
@@ -7,6 +7,7 @@ import com.simzoo.withmedical.enums.Gender;
 import com.simzoo.withmedical.enums.Role;
 import com.simzoo.withmedical.exception.CustomException;
 import com.simzoo.withmedical.exception.ErrorCode;
+import jakarta.persistence.ElementCollection;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
@@ -16,6 +17,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.OneToOne;
+import java.time.LocalDateTime;
 import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -41,8 +43,12 @@ public class MemberEntity extends BaseEntity{
     private String phoneNumber;
     private String password;
     private String passwordConfirm;
+    private LocalDateTime lastLogin;
+
     @Enumerated(EnumType.STRING)
-    private Role role;
+    @ElementCollection(fetch = LAZY)
+    @JoinColumn(name = "memberId")
+    private List<Role> roles;
 
     @OneToOne(fetch = LAZY)
     @JoinColumn(name = "memberId")
@@ -62,31 +68,35 @@ public class MemberEntity extends BaseEntity{
             .nickname(nickname)
             .gender(gender)
             .phoneNumber(phoneNumber)
-            .role(role)
+            .role(roles)
             .tutorProfile(tutorProfile)
             .tuteeProfiles(tuteeProfiles)
             .tuteeProfile(tuteeProfile)
             .build();
     }
 
-    public void saveTuteeProfile(TuteeProfileEntity profile) {
+    public void saveTuteeProfile(TuteeProfileEntity profile, Role role) {
         if (role == Role.TUTEE) {
             throw new CustomException(ErrorCode.PROFILE_ROLE_NOT_MATCH);
         }
         this.tuteeProfile = profile;
     }
 
-    public void saveTutorProfile(TutorProfileEntity profile) {
+    public void saveTutorProfile(TutorProfileEntity profile, Role role) {
         if (role == Role.TUTOR) {
             throw new CustomException(ErrorCode.PROFILE_ROLE_NOT_MATCH);
         }
         this.tutorProfile = profile;
     }
 
-    public void addTutorProfile(TuteeProfileEntity profile) {
+    public void addTutorProfile(TuteeProfileEntity profile, Role role) {
         if (role == Role.PARENT) {
             throw new CustomException(ErrorCode.PROFILE_ROLE_NOT_MATCH);
         }
         this.tuteeProfiles.add(profile);
+    }
+
+    public void updateLastLogin(LocalDateTime now) {
+        this.lastLogin = now;
     }
 }

--- a/backend/src/main/java/com/simzoo/withmedical/exception/CustomException.java
+++ b/backend/src/main/java/com/simzoo/withmedical/exception/CustomException.java
@@ -1,5 +1,8 @@
 package com.simzoo.withmedical.exception;
 
+import lombok.Getter;
+
+@Getter
 public class CustomException extends RuntimeException {
     private ErrorCode errorCode;
 

--- a/backend/src/main/java/com/simzoo/withmedical/exception/ErrorCode.java
+++ b/backend/src/main/java/com/simzoo/withmedical/exception/ErrorCode.java
@@ -14,7 +14,13 @@ public enum ErrorCode {
     PROFILE_ROLE_NOT_MATCH(HttpStatus.BAD_REQUEST, "사용자의 역할과 프로필이 일치하지 않습니다."),
     ALREADY_EXIST_MEMBER(HttpStatus.BAD_REQUEST, "이미 가입한 회원입니다."),
     VERIFY_NUMBER_NOT_MATCH(HttpStatus.BAD_REQUEST, "인증번호가 일치하지 않습니다."),
-    NOT_FOUND_VERIFY_NUMBER(HttpStatus.NOT_FOUND, "인증번호가 존재하지 않거나 만료되었습니다.")
+    NOT_FOUND_VERIFY_NUMBER(HttpStatus.NOT_FOUND, "인증번호가 존재하지 않거나 만료되었습니다."),
+    TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "토큰이 만료되었습니다."),
+    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다."),
+    DECRYPTION_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "복호화 과정에서 문제가 발생했습니다."),
+    ENCRYPTION_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "암호화 과정에서 문제가 발생했습니다."),
+    UNAUTHENTICATED_USER(HttpStatus.UNAUTHORIZED, "인증되지 않은 사용자입니다."),
+    NOT_MATCH_PASSWORD(HttpStatus.BAD_REQUEST, "비밀번호가 일치하지 않습니다.")
     ;
 
     private HttpStatus httpStatus;

--- a/backend/src/main/java/com/simzoo/withmedical/security/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/com/simzoo/withmedical/security/JwtAuthenticationFilter.java
@@ -1,0 +1,62 @@
+package com.simzoo.withmedical.security;
+
+import com.simzoo.withmedical.exception.CustomException;
+import com.simzoo.withmedical.exception.ErrorCode;
+import com.simzoo.withmedical.util.JwtUtil;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtUtil jwtUtil;
+    private final String ACCESS_TOKEN_HEADER = "Authorization";
+    private final String TOKEN_PREFIX = "Bearer ";
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+        FilterChain filterChain) throws ServletException, IOException {
+
+        String accessToken = resolveToken(request);
+        log.info("request path: {}", request.getRequestURI());
+
+        Authentication authentication = jwtUtil.getAuthentication(accessToken);
+        SecurityContextHolder.getContext()
+            .setAuthentication(authentication);
+        log.info("authentication: {}, {}", authentication.getPrincipal(),
+            authentication.getAuthorities());
+
+        request.setAttribute("nickname", jwtUtil.getUserVo(accessToken).getNickname());
+        request.setAttribute("loginId", jwtUtil.getUserVo(accessToken).getId());
+        filterChain.doFilter(request, response);
+    }
+
+    private String resolveToken(HttpServletRequest request) {
+
+        String token = request.getHeader(ACCESS_TOKEN_HEADER);
+
+        if (token == null) {
+            throw new CustomException(ErrorCode.UNAUTHENTICATED_USER);
+        }
+
+        if (!token.startsWith(TOKEN_PREFIX)) {
+            throw new CustomException(ErrorCode.INVALID_TOKEN);
+        }
+
+        token = token.replace(TOKEN_PREFIX, "");
+        jwtUtil.validateToken(token);
+
+        return token;
+    }
+}

--- a/backend/src/main/java/com/simzoo/withmedical/service/AuthService.java
+++ b/backend/src/main/java/com/simzoo/withmedical/service/AuthService.java
@@ -1,0 +1,49 @@
+package com.simzoo.withmedical.service;
+
+import com.simzoo.withmedical.dto.auth.JwtResponseDto;
+import com.simzoo.withmedical.dto.auth.LoginRequestDto;
+import com.simzoo.withmedical.entity.MemberEntity;
+import com.simzoo.withmedical.exception.CustomException;
+import com.simzoo.withmedical.exception.ErrorCode;
+import com.simzoo.withmedical.repository.MemberRepository;
+import com.simzoo.withmedical.util.AesUtil;
+import com.simzoo.withmedical.util.JwtUtil;
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+
+    private final MemberRepository memberRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final JwtUtil jwtUtil;
+
+    @Transactional
+    public JwtResponseDto login(LoginRequestDto requestDto) {
+
+        String phoneNumber = requestDto.getPhoneNumber();
+        String password = requestDto.getPassword();
+
+        MemberEntity memberEntity = memberRepository.findByPhoneNumber(AesUtil.encrypt(phoneNumber))
+            .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_USER));
+
+        if (notMatchPassword(memberEntity, password, passwordEncoder)) {
+            throw new CustomException(ErrorCode.NOT_MATCH_PASSWORD);
+        }
+
+        memberEntity.updateLastLogin(LocalDateTime.now());
+
+        return JwtResponseDto.builder().accessToken(
+            jwtUtil.generateAccessToken(memberEntity.getNickname(), memberEntity.getId(),
+                memberEntity.getRoles())).build();
+    }
+
+    private static boolean notMatchPassword(MemberEntity member, String password,
+        PasswordEncoder passwordEncoder) {
+        return !member.getPassword().equals(passwordEncoder.encode(password));
+    }
+}

--- a/backend/src/main/java/com/simzoo/withmedical/service/SignupService.java
+++ b/backend/src/main/java/com/simzoo/withmedical/service/SignupService.java
@@ -7,6 +7,7 @@ import com.simzoo.withmedical.repository.MemberRepository;
 import com.simzoo.withmedical.repository.TuteeProfileRepository;
 import com.simzoo.withmedical.repository.TutorProfileRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -17,23 +18,25 @@ public class SignupService {
     private final TutorProfileRepository tutorProfileRepository;
     private final MemberRepository memberRepository;
     private final TuteeProfileRepository tuteeProfileRepository;
+    private final PasswordEncoder passwordEncoder;
 
     @Transactional
     public MemberEntity signup(SignupRequestDto requestDto) {
 
-        MemberEntity member = memberRepository.save(requestDto.toMemberEntity());
+        MemberEntity member = memberRepository.save(requestDto.toMemberEntity(passwordEncoder));
 
-        if (member.getRole() == Role.TUTEE) {
+        if (requestDto.getRole() == Role.TUTEE) {
             member.saveTuteeProfile(
-                tuteeProfileRepository.save(requestDto.getTuteeProfile().toEntity(member)));
-        } else if (member.getRole() == Role.TUTOR) {
+                tuteeProfileRepository.save(requestDto.getTuteeProfile().toEntity(member)),
+                requestDto.getRole());
+        } else if (requestDto.getRole() == Role.TUTOR) {
             member.saveTutorProfile(
-                tutorProfileRepository.save(requestDto.getTutorProfile().toEntity(member)));
+                tutorProfileRepository.save(requestDto.getTutorProfile().toEntity(member)),
+                requestDto.getRole());
         } else {
             tuteeProfileRepository.saveAll(
                 requestDto.getTuteeProfiles().stream().map(e -> e.toEntity(member)).toList());
         }
-
         return member;
     }
 }

--- a/backend/src/main/java/com/simzoo/withmedical/util/AesUtil.java
+++ b/backend/src/main/java/com/simzoo/withmedical/util/AesUtil.java
@@ -1,0 +1,87 @@
+package com.simzoo.withmedical.util;
+
+import com.simzoo.withmedical.exception.CustomException;
+import com.simzoo.withmedical.exception.ErrorCode;
+import java.security.InvalidAlgorithmParameterException;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.util.Base64;
+import javax.crypto.BadPaddingException;
+import javax.crypto.Cipher;
+import javax.crypto.IllegalBlockSizeException;
+import javax.crypto.KeyGenerator;
+import javax.crypto.NoSuchPaddingException;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.IvParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
+import lombok.extern.slf4j.Slf4j;
+
+
+@Slf4j
+public class AesUtil {
+
+    private static final String TRANSFORMATION = "AES/CBC/PKCS5Padding";
+    private static final String ALGORITHM = "AES";
+    // 환경 변수에서 Secret Key 불러오기
+    private static final String SECRET_KEY = System.getenv("MY_SECRET_KEY");
+
+    public static String encrypt(String input) {
+        try {
+            Cipher cipher = Cipher.getInstance(AesUtil.TRANSFORMATION);
+            IvParameterSpec iv = generateIv();
+            SecretKey key = new SecretKeySpec(Base64.getUrlDecoder().decode(SECRET_KEY.getBytes()), ALGORITHM);
+            cipher.init(Cipher.ENCRYPT_MODE, key, iv);
+            byte[] cipherText = cipher.doFinal(input.getBytes());
+            byte[] ivBytes = iv.getIV();
+
+            return Base64.getEncoder().encodeToString(ivBytes) + ":" + Base64.getEncoder()
+                .encodeToString(cipherText);
+        } catch (NoSuchAlgorithmException | NoSuchPaddingException | InvalidKeyException |
+                 InvalidAlgorithmParameterException | BadPaddingException |
+                 IllegalBlockSizeException exception) {
+            log.error(exception.getMessage(), exception);
+            throw new CustomException(ErrorCode.ENCRYPTION_ERROR);
+        }
+    }
+
+    public static String decrypt(String cipherText) {
+        try {
+            String[] parts = cipherText.split(":");
+            byte[] ivBytes = Base64.getDecoder().decode(parts[0]);
+            byte[] cipherBytes = Base64.getDecoder().decode(parts[1]);
+            IvParameterSpec iv = new IvParameterSpec(ivBytes);
+            SecretKey key = new SecretKeySpec(Base64.getUrlDecoder().decode(SECRET_KEY.getBytes()), ALGORITHM);
+            Cipher cipher = Cipher.getInstance(TRANSFORMATION);
+            cipher.init(Cipher.DECRYPT_MODE, key, iv);
+            log.info("cipher bytes: {}", Base64.getEncoder().encodeToString(cipherBytes));
+            byte[] plainText = cipher.doFinal(cipherBytes);
+            return new String(plainText);
+        } catch (NoSuchAlgorithmException | NoSuchPaddingException | InvalidKeyException |
+                 InvalidAlgorithmParameterException | BadPaddingException |
+                 IllegalBlockSizeException exception) {
+            log.error(exception.getMessage());
+            throw new CustomException(ErrorCode.DECRYPTION_ERROR);
+        }
+    }
+
+    private static SecretKey generateKey(int n)
+        throws NoSuchAlgorithmException {
+        KeyGenerator keyGenerator = KeyGenerator.getInstance(ALGORITHM);
+        keyGenerator.init(n);
+        SecretKey key = keyGenerator.generateKey();
+        return key;
+    }
+
+    private static IvParameterSpec generateIv() {
+        byte[] iv = new byte[16];
+        new SecureRandom().nextBytes(iv);
+        return new IvParameterSpec(iv);
+    }
+
+    private static byte[] getSalt() {
+        byte[] salt = new byte[16];
+        new SecureRandom().nextBytes(salt);
+        return salt;
+    }
+}

--- a/backend/src/main/java/com/simzoo/withmedical/util/JwtUtil.java
+++ b/backend/src/main/java/com/simzoo/withmedical/util/JwtUtil.java
@@ -1,0 +1,132 @@
+package com.simzoo.withmedical.util;
+
+import com.simzoo.withmedical.enums.Role;
+import com.simzoo.withmedical.exception.CustomException;
+import com.simzoo.withmedical.exception.ErrorCode;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class JwtUtil {
+
+    @Value("${jwt.secret}")
+    private String secret;
+
+    private final long ACCESS_TOKEN_EXPIRATION = 1000 * 60 * 60; //1시간
+
+    private final long REFRESH_TOKEN_EXPIRATION = 1000 * 60 * 60 * 24 * 7; //1주일
+
+    public String generateAccessToken(String nickname, Long userId, List<Role> roles) {
+
+        SecretKey key = new SecretKeySpec(secret.getBytes(), "HmacSHA256");
+
+        return createToken(nickname, userId, roles, key, ACCESS_TOKEN_EXPIRATION);
+    }
+
+    public String generateRefreshToken(String nickname, Long userId, List<Role> roles) {
+
+        SecretKey key = new SecretKeySpec(secret.getBytes(), "HmacSHA256");
+
+        return createToken(nickname, userId, roles, key, REFRESH_TOKEN_EXPIRATION);
+    }
+
+    public UserVo getUserVo(String token) {
+        Claims claims = extractAll(token);
+        return new UserVo(Long.valueOf(AesUtil.decrypt(claims.getId())),
+            AesUtil.decrypt(claims.getSubject()));
+    }
+
+    public boolean validateToken(String token) throws CustomException {
+
+        SecretKey key = new SecretKeySpec(secret.getBytes(), "HmacSHA256");
+
+        expiredToken(token);
+
+        try {
+            Jwts.parser()
+                .verifyWith(key)
+                .build()
+                .parseSignedClaims(token);
+        } catch (JwtException | IllegalArgumentException exception) {
+            log.error(exception.getMessage(), exception);
+            throw new CustomException(ErrorCode.INVALID_TOKEN);
+        }
+
+        return true;
+    }
+
+    public boolean expiredToken(String token) throws CustomException{
+        if (new Date().after(extractAll(token).getExpiration())) {
+            throw new CustomException(ErrorCode.TOKEN_EXPIRED);
+        }
+        return false;
+    }
+
+    public Authentication getAuthentication(String token) {
+
+        String nickname = AesUtil.decrypt(extractAll(token).getSubject());
+        List<Role> roles = extractRoles(token);
+
+        User userDetails = new User(nickname, "",
+            roles.stream()
+                .map(e -> new SimpleGrantedAuthority(e.name())).toList());
+
+        return new UsernamePasswordAuthenticationToken(userDetails, "", userDetails.getAuthorities());
+    }
+
+    private String createToken(String nickname, Long userId, List<Role> roles, SecretKey key,
+        Long expiration) {
+
+        Map<String, Object> claims = new HashMap<>();
+
+        claims.put("roles", AesUtil.encrypt(roles.stream().map(Enum::name).toList().toString()));
+
+        return Jwts.builder()
+            .subject(AesUtil.encrypt(nickname))
+            .id(AesUtil.encrypt(userId.toString()))
+            .claims(claims)
+            .issuedAt(new Date())
+            .expiration(Date.from(Instant.now().plusMillis(expiration)))
+            .signWith(key)
+            .compact();
+    }
+
+    private Claims extractAll(String token) {
+        SecretKey key = new SecretKeySpec(secret.getBytes(), "HmacSHA256");
+
+        return Jwts.parser()
+            .verifyWith(key)
+            .build()
+            .parseSignedClaims(token)
+            .getPayload();
+    }
+
+    private List<Role> extractRoles(String token) {
+        String decryptedRoles = AesUtil.decrypt(extractAll(token).get("roles", String.class));
+
+        return Arrays.stream(
+                decryptedRoles
+                    .replace("[", "")
+                    .replace("]", "")
+                    .split(","))
+            .map(Role::valueOf).toList();
+    }
+
+}

--- a/backend/src/main/java/com/simzoo/withmedical/util/UserVo.java
+++ b/backend/src/main/java/com/simzoo/withmedical/util/UserVo.java
@@ -1,0 +1,13 @@
+package com.simzoo.withmedical.util;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class UserVo {
+    private Long id;
+    private String nickname;
+}

--- a/backend/src/test/java/com/simzoo/withmedical/util/AesUtilTest.java
+++ b/backend/src/test/java/com/simzoo/withmedical/util/AesUtilTest.java
@@ -1,0 +1,25 @@
+package com.simzoo.withmedical.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class AesUtilTest {
+
+    @Test
+    void aesTest() {
+        //given
+        String plainText = "Hello World!";
+        String encryptedText = AesUtil.encrypt(plainText);
+        String decryptedText = AesUtil.decrypt(encryptedText);
+
+
+        //when
+        //then
+        assertEquals(plainText, decryptedText);
+
+    }
+}

--- a/backend/src/test/java/com/simzoo/withmedical/util/KeyGenerate.java
+++ b/backend/src/test/java/com/simzoo/withmedical/util/KeyGenerate.java
@@ -1,0 +1,19 @@
+package com.simzoo.withmedical.util;
+
+import java.security.SecureRandom;
+import java.util.Base64;
+import javax.crypto.KeyGenerator;
+import javax.crypto.SecretKey;
+
+public class KeyGenerate {
+
+    public static void main(String[] args) throws Exception {
+        KeyGenerator keyGen = KeyGenerator.getInstance("AES");
+        keyGen.init(256, new SecureRandom());
+        SecretKey key = keyGen.generateKey();
+
+        String base64key = Base64.getUrlEncoder().withoutPadding().encodeToString(key.getEncoded());
+        System.out.println("key encoded: " + base64key);
+    }
+
+}


### PR DESCRIPTION
### 이 PR을 통해 해결하려는 문제
- 회원 로그인 시, JWT 토큰을 발행한다. 
- JWT 토큰에 회원정보 저장 및 DB에 회원정보를 저장할 때 민감한 정보는 암호화한다. 
### 이 PR에서 변경된 사항
**암호화**
- AesUtil, AesUtilTest : Aes256 암호화 유틸 클래스. 전화번호 암호화 저장, jwt 생성 시 페이로드 암호화에 사용
- KeyGenerate : AES secretKey 생성 시 사용
- SignupRequestDto, SignupService : toMemberEntity()에 암호화 추가

**로그인**
- Spring Security 설정
  - SecurityConfig
  - JwtAuthenticationFilter : SecurityContext에 인증정보 저장, Jwt 유효성 검증
  - CustomUserDetailsService, CustomUserDetails :
- LoginRequestDto : login Dto
- JWT 인증
  - JwtUtil: 토큰 발행, 토큰 정보 추출 등 핵심 로직
  - JwtResponseDto: 로그인 이후 토큰 반환 객체
  - JwtAuthenticationFilter: 요청 시 JWT 토큰을 검증하는 필터
  - UserVo : 사용자 기본 정보를 담고 있는 객체. 토큰에 사용.
- AuthService, AuthController

**기타**
- MemberResponseDto : Role role -> List<Role> role
- MemberEntity : Role role -> List<Role> role , lastLogin 필드 추가
- ErrorCode 추가
- CustomException : Getter 추가


### 참고 스크린샷

### 기타

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 -->
- [ ] 테스트 코드
- [ ] API 테스트
