### PR TITLE
fix&feat auth-002 MemberEntity role 타입 수정에 따른 수정, 로그아웃,ArgumenResolver 구현

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -10,3 +10,4 @@
 .idea
 # security
 application.yml
+properties.env

--- a/backend/src/main/java/com/simzoo/withmedical/config/SecurityConfig.java
+++ b/backend/src/main/java/com/simzoo/withmedical/config/SecurityConfig.java
@@ -1,7 +1,7 @@
 package com.simzoo.withmedical.config;
 
-import com.simzoo.withmedical.security.CustomUserDetailsService;
 import com.simzoo.withmedical.security.JwtAuthenticationFilter;
+import com.simzoo.withmedical.service.LogoutService;
 import com.simzoo.withmedical.util.JwtUtil;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -22,15 +22,11 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 public class SecurityConfig {
 
     private final JwtUtil jwtUtil;
-    private final CustomUserDetailsService customUserDetailsService;
+    private final LogoutService logoutService;
 
     private static final List<String> PERMIT_ALL_URLS = List.of(
-        "/index.html",
-        "/css/**",
-        "/images/**",
-        "/js/**",
-        "/swagger-ui/*",
-        "v3/api-docs/**"
+        "/index.html", "/css/**", "/images/**", "/js/**", "/swagger-ui/*", "v3/api-docs/**",
+        "/", "/auth/login", "/signup"
     );
 
     @Bean
@@ -55,7 +51,7 @@ public class SecurityConfig {
 
     @Bean
     public JwtAuthenticationFilter jwtAuthenticationFilter() {
-        return new JwtAuthenticationFilter(jwtUtil);
+        return new JwtAuthenticationFilter(jwtUtil, logoutService);
     }
 
     @Bean

--- a/backend/src/main/java/com/simzoo/withmedical/controller/AuthController.java
+++ b/backend/src/main/java/com/simzoo/withmedical/controller/AuthController.java
@@ -3,22 +3,34 @@ package com.simzoo.withmedical.controller;
 import com.simzoo.withmedical.dto.auth.JwtResponseDto;
 import com.simzoo.withmedical.dto.auth.LoginRequestDto;
 import com.simzoo.withmedical.service.AuthService;
+import com.simzoo.withmedical.service.LogoutService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
+@RequestMapping("/auth")
 @Slf4j
 public class AuthController {
 
     private final AuthService authService;
+    private final LogoutService logoutService;
 
     @PostMapping("/login")
     public ResponseEntity<JwtResponseDto> login(@RequestBody LoginRequestDto requestDto) {
         return ResponseEntity.ok(authService.login(requestDto));
+    }
+
+    @PostMapping("/logout")
+    public ResponseEntity<?> logout(@RequestHeader(name = "Authorization") String token) {
+
+        logoutService.logout(token);
+        return ResponseEntity.ok().build();
     }
 }

--- a/backend/src/main/java/com/simzoo/withmedical/controller/ReviewController.java
+++ b/backend/src/main/java/com/simzoo/withmedical/controller/ReviewController.java
@@ -4,6 +4,7 @@ import com.simzoo.withmedical.dto.ReviewRequestDto;
 import com.simzoo.withmedical.dto.ReviewResponseDto;
 import com.simzoo.withmedical.dto.UpdateReviewRequestDto;
 import com.simzoo.withmedical.service.ReviewService;
+import com.simzoo.withmedical.util.resolver.LoginId;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -30,9 +31,8 @@ public class ReviewController {
     /**
      * 리뷰 생성
      */
-    //Todo 로그인 사용자 id 매개변수로 전달
     @PostMapping
-    public ResponseEntity<ReviewResponseDto> createReview(Long userId,
+    public ResponseEntity<ReviewResponseDto> createReview(@LoginId Long userId,
         @RequestBody ReviewRequestDto requestDto) {
 
         return ResponseEntity.ok(reviewService.saveReview(userId, requestDto).toResponseDto());

--- a/backend/src/main/java/com/simzoo/withmedical/dto/auth/LoginRequestDto.java
+++ b/backend/src/main/java/com/simzoo/withmedical/dto/auth/LoginRequestDto.java
@@ -1,5 +1,6 @@
 package com.simzoo.withmedical.dto.auth;
 
+import com.simzoo.withmedical.enums.Role;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -10,4 +11,5 @@ import lombok.NoArgsConstructor;
 public class LoginRequestDto {
     private String phoneNumber;
     private String password;
+    private Role role;
 }

--- a/backend/src/main/java/com/simzoo/withmedical/dto/chat/ChatMessageResponseDto.java
+++ b/backend/src/main/java/com/simzoo/withmedical/dto/chat/ChatMessageResponseDto.java
@@ -1,7 +1,6 @@
 package com.simzoo.withmedical.dto.chat;
 
 import com.querydsl.core.annotations.QueryProjection;
-import com.simzoo.withmedical.enums.Role;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -12,14 +11,12 @@ import lombok.NoArgsConstructor;
 public class ChatMessageResponseDto {
     Long senderId;
     String senderNickname;
-    Role senderRole;
     String message;
 
     @QueryProjection
-    public ChatMessageResponseDto(Long senderId, String senderNickname, Role senderRole, String message) {
+    public ChatMessageResponseDto(Long senderId, String senderNickname, String message) {
         this.senderId = senderId;
         this.senderNickname = senderNickname;
-        this.senderRole = senderRole;
         this.message = message;
     }
 }

--- a/backend/src/main/java/com/simzoo/withmedical/entity/ChatMessageEntity.java
+++ b/backend/src/main/java/com/simzoo/withmedical/entity/ChatMessageEntity.java
@@ -44,7 +44,6 @@ public class ChatMessageEntity extends BaseEntity{
             .senderId(sender.getId())
             .message(message)
             .senderNickname(sender.getNickname())
-            .senderRole(sender.getRole())
             .build();
     }
 }

--- a/backend/src/main/java/com/simzoo/withmedical/entity/MemberEntity.java
+++ b/backend/src/main/java/com/simzoo/withmedical/entity/MemberEntity.java
@@ -7,6 +7,8 @@ import com.simzoo.withmedical.enums.Gender;
 import com.simzoo.withmedical.enums.Role;
 import com.simzoo.withmedical.exception.CustomException;
 import com.simzoo.withmedical.exception.ErrorCode;
+import jakarta.persistence.CollectionTable;
+import jakarta.persistence.Column;
 import jakarta.persistence.ElementCollection;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -47,7 +49,8 @@ public class MemberEntity extends BaseEntity{
 
     @Enumerated(EnumType.STRING)
     @ElementCollection(fetch = LAZY)
-    @JoinColumn(name = "memberId")
+    @CollectionTable(name = "memberRoles", joinColumns = @JoinColumn(name = "memberId"))
+    @Column(name = "role")
     private List<Role> roles;
 
     @OneToOne(fetch = LAZY)

--- a/backend/src/main/java/com/simzoo/withmedical/repository/chat/message/ChatMessageRepositoryCustomImpl.java
+++ b/backend/src/main/java/com/simzoo/withmedical/repository/chat/message/ChatMessageRepositoryCustomImpl.java
@@ -25,7 +25,6 @@ public class ChatMessageRepositoryCustomImpl implements ChatMessageRepositoryCus
                 new QChatMessageResponseDto(
                     chatMessage.sender.id,
                     chatMessage.sender.nickname,
-                    chatMessage.sender.role,
                     chatMessage.message))
             .from(chatMessage)
             .where(chatMessage.chatRoom.id.eq(roomId))

--- a/backend/src/main/java/com/simzoo/withmedical/security/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/com/simzoo/withmedical/security/JwtAuthenticationFilter.java
@@ -2,6 +2,7 @@ package com.simzoo.withmedical.security;
 
 import com.simzoo.withmedical.exception.CustomException;
 import com.simzoo.withmedical.exception.ErrorCode;
+import com.simzoo.withmedical.service.LogoutService;
 import com.simzoo.withmedical.util.JwtUtil;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
@@ -23,6 +24,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private final JwtUtil jwtUtil;
     private final String ACCESS_TOKEN_HEADER = "Authorization";
     private final String TOKEN_PREFIX = "Bearer ";
+    private final LogoutService logoutService;
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
@@ -46,7 +48,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
         String token = request.getHeader(ACCESS_TOKEN_HEADER);
 
-        if (token == null) {
+        if (token == null && logoutService.isLoggedOut(token)) {
             throw new CustomException(ErrorCode.UNAUTHENTICATED_USER);
         }
 

--- a/backend/src/main/java/com/simzoo/withmedical/service/AuthService.java
+++ b/backend/src/main/java/com/simzoo/withmedical/service/AuthService.java
@@ -39,7 +39,7 @@ public class AuthService {
 
         return JwtResponseDto.builder().accessToken(
             jwtUtil.generateAccessToken(memberEntity.getNickname(), memberEntity.getId(),
-                memberEntity.getRoles())).build();
+                requestDto.getRole())).build();
     }
 
     private static boolean notMatchPassword(MemberEntity member, String password,

--- a/backend/src/main/java/com/simzoo/withmedical/service/ChatService.java
+++ b/backend/src/main/java/com/simzoo/withmedical/service/ChatService.java
@@ -38,11 +38,9 @@ public class ChatService {
         MemberEntity participant1 = members.get(senderId);
         MemberEntity participant2 = members.get(recipientId);
 
-        String title = String.format("%s(%s) & %s(%s)의 대화",
+        String title = String.format("%s & %s의 대화",
             participant1.getNickname(),
-            participant1.getRole().name(),
-            participant2.getNickname(),
-            participant2.getRole().name()
+            participant2.getNickname()
         );
 
         ChatRoomEntity chatRoomEntity = ChatRoomEntity.builder()

--- a/backend/src/main/java/com/simzoo/withmedical/service/LogoutService.java
+++ b/backend/src/main/java/com/simzoo/withmedical/service/LogoutService.java
@@ -1,0 +1,30 @@
+package com.simzoo.withmedical.service;
+
+import com.simzoo.withmedical.util.JwtUtil;
+import java.time.Duration;
+import java.time.Instant;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class LogoutService {
+
+    private final RedisTemplate<String, String> redisTemplate;
+    private final JwtUtil jwtUtil;
+
+    @Transactional
+    public void logout(String token) {
+        ValueOperations<String, String> ops = redisTemplate.opsForValue();
+        long expirationTime = jwtUtil.extractExpiration(token) - Instant.now().toEpochMilli(); // 남은 유효 시간 계산
+        ops.set(token, "logout", Duration.ofMillis(expirationTime));
+    }
+
+    @Transactional
+    public boolean isLoggedOut(String token) {
+        return Boolean.TRUE.equals(redisTemplate.hasKey(token));
+    }
+}

--- a/backend/src/main/java/com/simzoo/withmedical/util/JwtUtil.java
+++ b/backend/src/main/java/com/simzoo/withmedical/util/JwtUtil.java
@@ -7,7 +7,6 @@ import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
 import java.time.Instant;
-import java.util.Arrays;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
@@ -33,18 +32,18 @@ public class JwtUtil {
 
     private final long REFRESH_TOKEN_EXPIRATION = 1000 * 60 * 60 * 24 * 7; //1주일
 
-    public String generateAccessToken(String nickname, Long userId, List<Role> roles) {
+    public String generateAccessToken(String nickname, Long userId, Role role) {
 
         SecretKey key = new SecretKeySpec(secret.getBytes(), "HmacSHA256");
 
-        return createToken(nickname, userId, roles, key, ACCESS_TOKEN_EXPIRATION);
+        return createToken(nickname, userId, role, key, ACCESS_TOKEN_EXPIRATION);
     }
 
-    public String generateRefreshToken(String nickname, Long userId, List<Role> roles) {
+    public String generateRefreshToken(String nickname, Long userId, Role role) {
 
         SecretKey key = new SecretKeySpec(secret.getBytes(), "HmacSHA256");
 
-        return createToken(nickname, userId, roles, key, REFRESH_TOKEN_EXPIRATION);
+        return createToken(nickname, userId, role, key, REFRESH_TOKEN_EXPIRATION);
     }
 
     public UserVo getUserVo(String token) {
@@ -79,24 +78,27 @@ public class JwtUtil {
         return false;
     }
 
+    public long extractExpiration(String token) {
+        return extractAll(token).getExpiration().getTime();
+    }
+
     public Authentication getAuthentication(String token) {
 
         String nickname = AesUtil.decrypt(extractAll(token).getSubject());
-        List<Role> roles = extractRoles(token);
+        Role role = extractRole(token);
 
         User userDetails = new User(nickname, "",
-            roles.stream()
-                .map(e -> new SimpleGrantedAuthority(e.name())).toList());
+            List.of(new SimpleGrantedAuthority(role.name())));
 
         return new UsernamePasswordAuthenticationToken(userDetails, "", userDetails.getAuthorities());
     }
 
-    private String createToken(String nickname, Long userId, List<Role> roles, SecretKey key,
+    private String createToken(String nickname, Long userId, Role role, SecretKey key,
         Long expiration) {
 
         Map<String, Object> claims = new HashMap<>();
 
-        claims.put("roles", AesUtil.encrypt(roles.stream().map(Enum::name).toList().toString()));
+        claims.put("role", AesUtil.encrypt(role.name()));
 
         return Jwts.builder()
             .subject(AesUtil.encrypt(nickname))
@@ -118,15 +120,8 @@ public class JwtUtil {
             .getPayload();
     }
 
-    private List<Role> extractRoles(String token) {
-        String decryptedRoles = AesUtil.decrypt(extractAll(token).get("roles", String.class));
-
-        return Arrays.stream(
-                decryptedRoles
-                    .replace("[", "")
-                    .replace("]", "")
-                    .split(","))
-            .map(Role::valueOf).toList();
+    private Role extractRole(String token) {
+        return extractAll(token).get("role", Role.class);
     }
 
 }

--- a/backend/src/main/java/com/simzoo/withmedical/util/resolver/LoginId.java
+++ b/backend/src/main/java/com/simzoo/withmedical/util/resolver/LoginId.java
@@ -1,0 +1,12 @@
+package com.simzoo.withmedical.util.resolver;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface LoginId {
+
+}

--- a/backend/src/main/java/com/simzoo/withmedical/util/resolver/LoginUserResolver.java
+++ b/backend/src/main/java/com/simzoo/withmedical/util/resolver/LoginUserResolver.java
@@ -1,0 +1,24 @@
+package com.simzoo.withmedical.util.resolver;
+
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.context.request.RequestAttributes;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@Component
+public class LoginUserResolver implements HandlerMethodArgumentResolver {
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.getParameterAnnotation(LoginId.class) != null;
+    }
+
+    @Override
+    public Long resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
+        NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
+        return (Long) webRequest.getAttribute("loginId", RequestAttributes.SCOPE_REQUEST);
+    }
+}

--- a/backend/src/main/resources/data.sql
+++ b/backend/src/main/resources/data.sql
@@ -1,10 +1,19 @@
 -- 첫 번째 회원(Member 1: 튜티)
-INSERT INTO member (nickname, gender, phoneNumber, password, passwordConfirm, role, createdAt, updatedAt)
-VALUES ('심주', 'MALE', '010-1234-5678', 'password123', 'password123', 'TUTEE', NOW(), NOW());
+INSERT INTO member (nickname, gender, phoneNumber, password, passwordConfirm, createdAt, updatedAt)
+VALUES ('심주', 'MALE', '010-1234-5678', 'password123', 'password123', NOW(), NOW());
+
+-- member_roles 테이블에 역할 데이터 삽입
+-- ID는 이전 INSERT에서 생성된 member의 ID를 사용 (예: 1로 가정)
+INSERT INTO memberRoles (memberId, role)
+VALUES (1, 'TUTEE');
 
 -- 두 번째 회원(Member 2: 튜터)
-INSERT INTO member (nickname, gender, phoneNumber, password, passwordConfirm, role, createdAt, updatedAt)
-VALUES ('선생님', 'FEMALE', '010-9876-5432', 'password456', 'password456', 'TUTOR', NOW(), NOW());
+INSERT INTO member (nickname, gender, phoneNumber, password, passwordConfirm, createdAt, updatedAt)
+VALUES ('선생님', 'FEMALE', '010-9876-5432', 'password456', 'password456', NOW(), NOW());
+
+INSERT INTO memberRoles (memberId, role)
+VALUES (2, 'TUTOR');
+
 
 -- 튜터 프로필 생성
 INSERT INTO tutorProfile (memberId, location, university, status, createdAt, updatedAt)


### PR DESCRIPTION
### 이 PR을 통해 해결하려는 문제
- 로그인 시 역할(Role)을 선택한다.
- 로그아웃 기능을 구현
- token에 담긴 Id 정보를 가져오기 위한 ArgumentResolver 설정

### 이 PR에서 변경된 사항
Fix
- MemberEntity: roles 필드 @JoinColumn -> @CollectionTable 변경, @Column(name = "role") 추가
- LoginRequestDto: Role 필드 추가(로그인 시 권한 선택)
- JwtUtil : 로그인 시 선택한 Role 정보를 토큰에 담도록 설정
- ChatMessageResponseDto: role 필드 삭제
- ChatMessageEntity, ChatMessageRepositoryCustomImpl: role 필드 삭제에 따라 수정
- ChatService: 채팅방제목에 Role 표기 삭제

로그아웃
- LogoutService: 로그아웃 로직 구현. Redis 데이터베이스에 사용한 토큰 저장.
- JwtAuthenticationFilter: LogoutService의 isLoggedOut 메서드 사용하여 토큰의 유효성 검사
- SecurityConfig: LogoutService 주입

ArgumentResolver
- LoginId, LoginUserResolver: ArgumentResolver 설정
- ReviewController : create 메서드에 resolver 사용
- 
### 참고 스크린샷

### 기타

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 -->
- [ ] 테스트 코드
- [ ] API 테스트
