### PR TITLE
fix auth-003 로그인&회원가입 수정(휴대전화 해시로 암호화 저장, security 설정)

### DIFF
--- a/backend/src/main/java/com/simzoo/withmedical/config/SecurityConfig.java
+++ b/backend/src/main/java/com/simzoo/withmedical/config/SecurityConfig.java
@@ -26,7 +26,7 @@ public class SecurityConfig {
 
     private static final List<String> PERMIT_ALL_URLS = List.of(
         "/index.html", "/css/**", "/images/**", "/js/**", "/swagger-ui/*", "v3/api-docs/**",
-        "/", "/auth/login", "/signup"
+        "/", "/auth/login/**", "/send-one", "/signup/**"
     );
 
     @Bean
@@ -37,7 +37,7 @@ public class SecurityConfig {
                 request -> request
                     .requestMatchers(PERMIT_ALL_URLS.toArray(new String[0]))
                     .permitAll()
-                    .anyRequest().authenticated()
+                    .anyRequest().permitAll()
             )
             .sessionManagement(
                 session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
@@ -58,6 +58,4 @@ public class SecurityConfig {
     public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
     }
-
-
 }

--- a/backend/src/main/java/com/simzoo/withmedical/controller/AuthController.java
+++ b/backend/src/main/java/com/simzoo/withmedical/controller/AuthController.java
@@ -4,6 +4,8 @@ import com.simzoo.withmedical.dto.auth.JwtResponseDto;
 import com.simzoo.withmedical.dto.auth.LoginRequestDto;
 import com.simzoo.withmedical.service.AuthService;
 import com.simzoo.withmedical.service.LogoutService;
+import com.simzoo.withmedical.service.MemberService;
+import com.simzoo.withmedical.service.VerificationService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -11,6 +13,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -21,12 +24,22 @@ public class AuthController {
 
     private final AuthService authService;
     private final LogoutService logoutService;
+    private final VerificationService verificationService;
+    private final MemberService memberService;
 
     @PostMapping("/login")
     public ResponseEntity<JwtResponseDto> login(@RequestBody LoginRequestDto requestDto) {
         return ResponseEntity.ok(authService.login(requestDto));
     }
 
+    @PostMapping("/login/verify")
+    public ResponseEntity<?> verify(@RequestParam String receivePhone,
+        @RequestParam Integer verifyNumber) {
+
+        verificationService.verifyNumber(receivePhone, verifyNumber);
+        memberService.checkMemberExist(receivePhone);
+        return ResponseEntity.ok().build();
+    }
     @PostMapping("/logout")
     public ResponseEntity<?> logout(@RequestHeader(name = "Authorization") String token) {
 

--- a/backend/src/main/java/com/simzoo/withmedical/dto/auth/SignupRequestDto.java
+++ b/backend/src/main/java/com/simzoo/withmedical/dto/auth/SignupRequestDto.java
@@ -55,7 +55,7 @@ public class SignupRequestDto {
         return MemberEntity.builder()
             .nickname(nickname)
             .gender(gender)
-            .phoneNumber(AesUtil.decrypt(phoneNumber))
+            .phoneNumber(AesUtil.generateHash(phoneNumber))
             .password(passwordEncoder.encode(password))
             .build();
     }

--- a/backend/src/main/java/com/simzoo/withmedical/entity/MemberEntity.java
+++ b/backend/src/main/java/com/simzoo/withmedical/entity/MemberEntity.java
@@ -79,21 +79,21 @@ public class MemberEntity extends BaseEntity{
     }
 
     public void saveTuteeProfile(TuteeProfileEntity profile, Role role) {
-        if (role == Role.TUTEE) {
+        if (role != Role.TUTEE) {
             throw new CustomException(ErrorCode.PROFILE_ROLE_NOT_MATCH);
         }
         this.tuteeProfile = profile;
     }
 
     public void saveTutorProfile(TutorProfileEntity profile, Role role) {
-        if (role == Role.TUTOR) {
+        if (role != Role.TUTOR) {
             throw new CustomException(ErrorCode.PROFILE_ROLE_NOT_MATCH);
         }
         this.tutorProfile = profile;
     }
 
     public void addTutorProfile(TuteeProfileEntity profile, Role role) {
-        if (role == Role.PARENT) {
+        if (role != Role.PARENT) {
             throw new CustomException(ErrorCode.PROFILE_ROLE_NOT_MATCH);
         }
         this.tuteeProfiles.add(profile);

--- a/backend/src/main/java/com/simzoo/withmedical/service/AuthService.java
+++ b/backend/src/main/java/com/simzoo/withmedical/service/AuthService.java
@@ -28,7 +28,7 @@ public class AuthService {
         String phoneNumber = requestDto.getPhoneNumber();
         String password = requestDto.getPassword();
 
-        MemberEntity memberEntity = memberRepository.findByPhoneNumber(AesUtil.encrypt(phoneNumber))
+        MemberEntity memberEntity = memberRepository.findByPhoneNumber(AesUtil.generateHash(phoneNumber))
             .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_USER));
 
         if (notMatchPassword(memberEntity, password, passwordEncoder)) {
@@ -44,6 +44,6 @@ public class AuthService {
 
     private static boolean notMatchPassword(MemberEntity member, String password,
         PasswordEncoder passwordEncoder) {
-        return !member.getPassword().equals(passwordEncoder.encode(password));
+        return !passwordEncoder.matches(password, member.getPassword());
     }
 }

--- a/backend/src/main/java/com/simzoo/withmedical/service/LogoutService.java
+++ b/backend/src/main/java/com/simzoo/withmedical/service/LogoutService.java
@@ -18,6 +18,7 @@ public class LogoutService {
 
     @Transactional
     public void logout(String token) {
+        token = token.replace("Bearer ", "");
         ValueOperations<String, String> ops = redisTemplate.opsForValue();
         long expirationTime = jwtUtil.extractExpiration(token) - Instant.now().toEpochMilli(); // 남은 유효 시간 계산
         ops.set(token, "logout", Duration.ofMillis(expirationTime));

--- a/backend/src/main/java/com/simzoo/withmedical/util/AesUtil.java
+++ b/backend/src/main/java/com/simzoo/withmedical/util/AesUtil.java
@@ -2,8 +2,10 @@ package com.simzoo.withmedical.util;
 
 import com.simzoo.withmedical.exception.CustomException;
 import com.simzoo.withmedical.exception.ErrorCode;
+import java.nio.charset.StandardCharsets;
 import java.security.InvalidAlgorithmParameterException;
 import java.security.InvalidKeyException;
+import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
 import java.util.Base64;
@@ -47,6 +49,7 @@ public class AesUtil {
 
     public static String decrypt(String cipherText) {
         try {
+            log.info("cipherText: {}", cipherText);
             String[] parts = cipherText.split(":");
             byte[] ivBytes = Base64.getDecoder().decode(parts[0]);
             byte[] cipherBytes = Base64.getDecoder().decode(parts[1]);
@@ -62,6 +65,16 @@ public class AesUtil {
                  IllegalBlockSizeException exception) {
             log.error(exception.getMessage());
             throw new CustomException(ErrorCode.DECRYPTION_ERROR);
+        }
+    }
+
+    public static String generateHash(String input) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] hash = digest.digest(input.getBytes(StandardCharsets.UTF_8));
+            return Base64.getEncoder().encodeToString(hash);
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException(e);
         }
     }
 

--- a/backend/src/main/java/com/simzoo/withmedical/util/JwtUtil.java
+++ b/backend/src/main/java/com/simzoo/withmedical/util/JwtUtil.java
@@ -6,6 +6,7 @@ import com.simzoo.withmedical.exception.ErrorCode;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
 import java.time.Instant;
 import java.util.Date;
 import java.util.HashMap;
@@ -106,7 +107,7 @@ public class JwtUtil {
             .claims(claims)
             .issuedAt(new Date())
             .expiration(Date.from(Instant.now().plusMillis(expiration)))
-            .signWith(key)
+            .signWith(key, SignatureAlgorithm.HS256)
             .compact();
     }
 


### PR DESCRIPTION
### 이 PR을 통해 해결하려는 문제
- 프론트엔드와 연동하면서 버그가 발생하는 부분들 수정
- 휴대전화번호 암호화방식 수정
- Security 설정에 따른 요청 접근권한 필터링 버그 수정
- JwtUtil 페이로드 서명 메서드 코드 수정

### 이 PR에서 변경된 사항
암호화
- AesUtil: 해시생성 메서드 추가
- AuthService
  - 해시생성 및 저장 내용 반영
  - 비밀번호 비교. PasswordEncoder의 mathces() 메서드 사용
- JwtUtil: 페이로드 서명 시 메서드에 알고리즘 명시
- SignupRequestDto: 전화번호 저장 시 해시키 생성하여 저장

Security 설정
- SecurityConfig: permitall 리스트 추가
- JwtAuthenticationFilter
  - 로직 수정(token이 Null일 때 예외던지지 않고 필터넘기기)
  - 순환참조 수정(AuthService 주입 없애고 -> LogoutService 주입)

기타
- AuthController: login/verify 메서드 추가
- MemberEntity: 프로필 저장 메서드 오타 수정(== -> !=)
`    public void saveTuteeProfile(TuteeProfileEntity profile, Role role) {
        if (role != Role.TUTEE) {
            throw new CustomException(ErrorCode.PROFILE_ROLE_NOT_MATCH);
        }
        this.tuteeProfile = profile;
    }`

### 참고 스크린샷

### 기타

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 -->
- [ ] 테스트 코드
- [ ] API 테스트
