### PR TITLE
feat-back-tutor-001 선생님 프로필 조회 로직 구현

### DIFF
--- a/backend/src/main/java/com/simzoo/withmedical/config/SecurityConfig.java
+++ b/backend/src/main/java/com/simzoo/withmedical/config/SecurityConfig.java
@@ -7,6 +7,7 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -36,6 +37,8 @@ public class SecurityConfig {
             authorizeHttpRequests(
                 request -> request
                     .requestMatchers(PERMIT_ALL_URLS.toArray(new String[0]))
+                    .permitAll()
+                    .requestMatchers(HttpMethod.GET, "/tutor")
                     .permitAll()
                     .anyRequest().permitAll()
             )

--- a/backend/src/main/java/com/simzoo/withmedical/controller/TutorProfileController.java
+++ b/backend/src/main/java/com/simzoo/withmedical/controller/TutorProfileController.java
@@ -1,0 +1,41 @@
+package com.simzoo.withmedical.controller;
+
+import com.simzoo.withmedical.dto.TutorSimpleResponseDto;
+import com.simzoo.withmedical.dto.tutor.TutorProfileResponseDto;
+import com.simzoo.withmedical.service.TutorProfileService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort.Direction;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/tutor")
+public class TutorProfileController {
+
+    private final TutorProfileService tutorProfileService;
+
+    /**
+     * 선생님 프로필 전체 조회
+     */
+    @GetMapping
+    public ResponseEntity<Page<TutorSimpleResponseDto>> getTutorProfiles(
+        @PageableDefault(page = 0, size = 10, direction = Direction.ASC, sort = "createdAt") Pageable pageable) {
+
+        return ResponseEntity.ok(tutorProfileService.getTutorList(pageable));
+    }
+
+    /**
+     * 선생님 프로필 개별 조회
+     */
+    @GetMapping("/{tutorId}")
+    public ResponseEntity<TutorProfileResponseDto> getTutorProfile(@PathVariable Long tutorId) {
+        return ResponseEntity.ok(tutorProfileService.getTutorDetail(tutorId).toResponseDto());
+    }
+}

--- a/backend/src/main/java/com/simzoo/withmedical/dto/TutorSimpleResponseDto.java
+++ b/backend/src/main/java/com/simzoo/withmedical/dto/TutorSimpleResponseDto.java
@@ -1,0 +1,29 @@
+package com.simzoo.withmedical.dto;
+
+import com.querydsl.core.annotations.QueryProjection;
+import com.simzoo.withmedical.enums.Location;
+import com.simzoo.withmedical.enums.Subject;
+import com.simzoo.withmedical.enums.University;
+import java.util.List;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class TutorSimpleResponseDto {
+
+    private String nickname;
+    private University university;
+    private Location location;
+    private List<Subject> subjects;
+
+
+    @QueryProjection
+    public TutorSimpleResponseDto(String nickname, University university, Location location,
+        List<Subject> subjects) {
+        this.nickname = nickname;
+        this.university = university;
+        this.location = location;
+        this.subjects = subjects;
+    }
+}

--- a/backend/src/main/java/com/simzoo/withmedical/dto/auth/SignupRequestDto.java
+++ b/backend/src/main/java/com/simzoo/withmedical/dto/auth/SignupRequestDto.java
@@ -1,7 +1,7 @@
 package com.simzoo.withmedical.dto.auth;
 
 import com.simzoo.withmedical.dto.TuteeProfileRequestDto;
-import com.simzoo.withmedical.dto.TutorProfileRequestDto;
+import com.simzoo.withmedical.dto.tutor.TutorProfileRequestDto;
 import com.simzoo.withmedical.entity.MemberEntity;
 import com.simzoo.withmedical.enums.Gender;
 import com.simzoo.withmedical.enums.Role;

--- a/backend/src/main/java/com/simzoo/withmedical/dto/tutor/TutorProfileRequestDto.java
+++ b/backend/src/main/java/com/simzoo/withmedical/dto/tutor/TutorProfileRequestDto.java
@@ -1,4 +1,4 @@
-package com.simzoo.withmedical.dto;
+package com.simzoo.withmedical.dto.tutor;
 
 import com.simzoo.withmedical.entity.MemberEntity;
 import com.simzoo.withmedical.entity.TutorProfileEntity;

--- a/backend/src/main/java/com/simzoo/withmedical/dto/tutor/TutorProfileResponseDto.java
+++ b/backend/src/main/java/com/simzoo/withmedical/dto/tutor/TutorProfileResponseDto.java
@@ -1,0 +1,28 @@
+package com.simzoo.withmedical.dto.tutor;
+
+import com.simzoo.withmedical.enums.EnrollmentStatus;
+import com.simzoo.withmedical.enums.Gender;
+import com.simzoo.withmedical.enums.Location;
+import com.simzoo.withmedical.enums.Subject;
+import com.simzoo.withmedical.enums.University;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class TutorProfileResponseDto {
+    private Long tutorId;
+    private String nickname;
+    private Gender gender;
+    private List<Subject> subjects = new ArrayList<>();
+    private Location location;
+    private University university;
+    private EnrollmentStatus status;
+    private String description;
+}

--- a/backend/src/main/java/com/simzoo/withmedical/entity/TutorProfileEntity.java
+++ b/backend/src/main/java/com/simzoo/withmedical/entity/TutorProfileEntity.java
@@ -1,5 +1,6 @@
 package com.simzoo.withmedical.entity;
 
+import com.simzoo.withmedical.dto.tutor.TutorProfileResponseDto;
 import com.simzoo.withmedical.enums.EnrollmentStatus;
 import com.simzoo.withmedical.enums.Location;
 import com.simzoo.withmedical.enums.Subject;
@@ -56,4 +57,18 @@ public class TutorProfileEntity extends BaseEntity {
     private EnrollmentStatus status;
 
     private String description;
+
+    public TutorProfileResponseDto toResponseDto() {
+
+        return TutorProfileResponseDto.builder()
+            .tutorId(id)
+            .nickname(this.member.getNickname())
+            .gender(this.member.getGender())
+            .subjects(this.subjects)
+            .location(this.location)
+            .university(this.university)
+            .status(this.status)
+            .description(this.description)
+            .build();
+    }
 }

--- a/backend/src/main/java/com/simzoo/withmedical/repository/tutor/TutorProfileRepository.java
+++ b/backend/src/main/java/com/simzoo/withmedical/repository/tutor/TutorProfileRepository.java
@@ -1,10 +1,10 @@
-package com.simzoo.withmedical.repository;
+package com.simzoo.withmedical.repository.tutor;
 
 import com.simzoo.withmedical.entity.TutorProfileEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface TutorProfileRepository extends JpaRepository<TutorProfileEntity, Long> {
+public interface TutorProfileRepository extends JpaRepository<TutorProfileEntity, Long>, TutorProfileRepositoryCustom {
 
 }

--- a/backend/src/main/java/com/simzoo/withmedical/repository/tutor/TutorProfileRepositoryCustom.java
+++ b/backend/src/main/java/com/simzoo/withmedical/repository/tutor/TutorProfileRepositoryCustom.java
@@ -1,0 +1,9 @@
+package com.simzoo.withmedical.repository.tutor;
+
+import com.simzoo.withmedical.dto.TutorSimpleResponseDto;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface TutorProfileRepositoryCustom {
+    Page<TutorSimpleResponseDto> findTutorProfileDtos(Pageable pageable);
+}

--- a/backend/src/main/java/com/simzoo/withmedical/repository/tutor/TutorProfileRepositoryCustomImpl.java
+++ b/backend/src/main/java/com/simzoo/withmedical/repository/tutor/TutorProfileRepositoryCustomImpl.java
@@ -1,0 +1,39 @@
+package com.simzoo.withmedical.repository.tutor;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.simzoo.withmedical.dto.QTutorSimpleResponseDto;
+import com.simzoo.withmedical.dto.TutorSimpleResponseDto;
+import com.simzoo.withmedical.entity.QTutorProfileEntity;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
+@RequiredArgsConstructor
+public class TutorProfileRepositoryCustomImpl implements TutorProfileRepositoryCustom {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public Page<TutorSimpleResponseDto> findTutorProfileDtos(Pageable pageable) {
+
+        QTutorProfileEntity tutorProfile = QTutorProfileEntity.tutorProfileEntity;
+
+        List<TutorSimpleResponseDto> results = jpaQueryFactory.select(new QTutorSimpleResponseDto(
+                tutorProfile.member.nickname,
+                tutorProfile.university,
+                tutorProfile.location,
+                tutorProfile.subjects
+            )).from(tutorProfile)
+            .offset(pageable.getOffset())
+            .limit(pageable.getPageSize())
+            .fetch();
+
+        Long total = jpaQueryFactory.select(tutorProfile.count())
+            .from(tutorProfile)
+            .fetchOne();
+
+        return new PageImpl<>(results, pageable, total);
+    }
+}

--- a/backend/src/main/java/com/simzoo/withmedical/service/SignupService.java
+++ b/backend/src/main/java/com/simzoo/withmedical/service/SignupService.java
@@ -5,7 +5,7 @@ import com.simzoo.withmedical.entity.MemberEntity;
 import com.simzoo.withmedical.enums.Role;
 import com.simzoo.withmedical.repository.MemberRepository;
 import com.simzoo.withmedical.repository.TuteeProfileRepository;
-import com.simzoo.withmedical.repository.TutorProfileRepository;
+import com.simzoo.withmedical.repository.tutor.TutorProfileRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;

--- a/backend/src/main/java/com/simzoo/withmedical/service/TutorProfileService.java
+++ b/backend/src/main/java/com/simzoo/withmedical/service/TutorProfileService.java
@@ -1,0 +1,36 @@
+package com.simzoo.withmedical.service;
+
+import com.simzoo.withmedical.dto.TutorSimpleResponseDto;
+import com.simzoo.withmedical.entity.TutorProfileEntity;
+import com.simzoo.withmedical.exception.CustomException;
+import com.simzoo.withmedical.exception.ErrorCode;
+import com.simzoo.withmedical.repository.tutor.TutorProfileRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class TutorProfileService {
+
+    private final TutorProfileRepository tutorProfileRepository;
+
+    /**
+     * 선생님 전체 조회
+     */
+    @Transactional(readOnly = true)
+    public Page<TutorSimpleResponseDto> getTutorList(Pageable pageable) {
+        return tutorProfileRepository.findTutorProfileDtos(pageable);
+    }
+
+    /**
+     * 선생님 개별조회
+     */
+    @Transactional(readOnly = true)
+    public TutorProfileEntity getTutorDetail(Long tutorId) {
+        return tutorProfileRepository.findById(tutorId)
+            .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_USER));
+    }
+}


### PR DESCRIPTION
### 이 PR을 통해 해결하려는 문제
- 선생님 프로필을 목록조회, 개별조회할 수 있다(백엔드 코드 구현)

### 이 PR에서 변경된 사항
전체 리스트 조회
- Pageable 객체를 사용하여 pagination 기능 구현
- TutorSimpleResponseDto의 Page로 반환
- QueryDsl 사용하여 dto로 조회

개별조회
- tutorId 값을 받아 개별조회
- TutorProfileResponseDto 객체로 반환
- TutorProfileEntity에 toResponseDto() 생성

### 참고 스크린샷

### 기타

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 -->
- [ ] 테스트 코드
- [ ] API 테스트
