### PR TITLE
feat-back-cancelAccount&passwordChange 회원 탈퇴, 비밀번호 변경 로직 구현

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -10,4 +10,5 @@
 .idea
 # security
 application.yml
+application-test.yml
 properties.env

--- a/backend/src/main/java/com/simzoo/withmedical/controller/MemberController.java
+++ b/backend/src/main/java/com/simzoo/withmedical/controller/MemberController.java
@@ -1,9 +1,11 @@
 package com.simzoo.withmedical.controller;
 
-import com.simzoo.withmedical.dto.MemberResponseDto;
-import com.simzoo.withmedical.dto.UpdateMemberRequestDto;
+import com.simzoo.withmedical.dto.member.ChangePasswordDto;
+import com.simzoo.withmedical.dto.member.MemberResponseDto;
+import com.simzoo.withmedical.dto.member.UpdateMemberRequestDto;
 import com.simzoo.withmedical.dto.tutee.TuteeProfileRequestDto;
 import com.simzoo.withmedical.enums.Role;
+import com.simzoo.withmedical.service.AuthService;
 import com.simzoo.withmedical.service.MemberService;
 import com.simzoo.withmedical.util.JwtUtil;
 import com.simzoo.withmedical.util.resolver.LoginId;
@@ -12,6 +14,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -25,19 +28,29 @@ public class MemberController {
 
     private final MemberService memberService;
     private final JwtUtil jwtUtil;
+    private final AuthService authService;
 
+    /**
+     * 내 정보 조회
+     */
     @GetMapping("/me")
     public ResponseEntity<MemberResponseDto> getMyInfo(@LoginId Long userId) {
         log.info("userId = {}", userId);
         return ResponseEntity.ok(memberService.getMyInfo(userId).toResponseDto());
     }
 
+    /**
+     * 내 정보 수정
+     */
     @PutMapping("/me")
     public ResponseEntity<MemberResponseDto> updateMyInfo(@LoginId Long userId,
         @RequestBody UpdateMemberRequestDto requestDto) {
         return ResponseEntity.ok(memberService.updateMember(userId, requestDto).toResponseDto());
     }
 
+    /**
+     * 프로필 추가
+     */
     @PutMapping("/me/add-profile")
     public ResponseEntity<MemberResponseDto> addProfile(
         @RequestHeader(name = "Authorization") String token,
@@ -51,6 +64,9 @@ public class MemberController {
             memberService.addTuteeProfile(userId, role, requestDto).toResponseDto());
     }
 
+    /**
+     * 학생 프로필 수정
+     */
     @PutMapping("/parent/tutee")
     public ResponseEntity<MemberResponseDto> updateProfile(@LoginId Long userId,
         @RequestBody UpdateMemberRequestDto requestDto) {
@@ -65,5 +81,22 @@ public class MemberController {
         memberService.removeProfile(userId, tuteeId);
 
         return ResponseEntity.ok().build();
+    }
+
+    @DeleteMapping("/me")
+    public ResponseEntity<Void> cancleAccount(@LoginId Long userId) {
+
+        memberService.deleteMember(userId);
+
+        return ResponseEntity.ok().build();
+    }
+
+    @PatchMapping("/me/password")
+    public ResponseEntity<?> changePassword(@LoginId Long userId,
+        @RequestBody ChangePasswordDto requestDto) {
+
+        authService.changeMyPassword(userId, requestDto);
+
+        return null;
     }
 }

--- a/backend/src/main/java/com/simzoo/withmedical/controller/SignupController.java
+++ b/backend/src/main/java/com/simzoo/withmedical/controller/SignupController.java
@@ -1,6 +1,6 @@
 package com.simzoo.withmedical.controller;
 
-import com.simzoo.withmedical.dto.MemberResponseDto;
+import com.simzoo.withmedical.dto.member.MemberResponseDto;
 import com.simzoo.withmedical.dto.auth.SignupRequestDto;
 import com.simzoo.withmedical.service.MemberService;
 import com.simzoo.withmedical.service.SignupService;

--- a/backend/src/main/java/com/simzoo/withmedical/dto/member/ChangePasswordDto.java
+++ b/backend/src/main/java/com/simzoo/withmedical/dto/member/ChangePasswordDto.java
@@ -1,0 +1,18 @@
+package com.simzoo.withmedical.dto.member;
+
+import com.simzoo.withmedical.util.validator.Password;
+import com.simzoo.withmedical.util.validator.PasswordConfirm;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@PasswordConfirm
+public class ChangePasswordDto {
+    private String oldPassword;
+
+    @Password
+    private String newPassword;
+
+    private String confirmPassword;
+}

--- a/backend/src/main/java/com/simzoo/withmedical/dto/member/MemberResponseDto.java
+++ b/backend/src/main/java/com/simzoo/withmedical/dto/member/MemberResponseDto.java
@@ -1,4 +1,4 @@
-package com.simzoo.withmedical.dto;
+package com.simzoo.withmedical.dto.member;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;

--- a/backend/src/main/java/com/simzoo/withmedical/dto/member/UpdateMemberRequestDto.java
+++ b/backend/src/main/java/com/simzoo/withmedical/dto/member/UpdateMemberRequestDto.java
@@ -1,4 +1,4 @@
-package com.simzoo.withmedical.dto;
+package com.simzoo.withmedical.dto.member;
 
 import com.simzoo.withmedical.enums.EnrollmentStatus;
 import com.simzoo.withmedical.enums.Gender;

--- a/backend/src/main/java/com/simzoo/withmedical/entity/MemberEntity.java
+++ b/backend/src/main/java/com/simzoo/withmedical/entity/MemberEntity.java
@@ -2,8 +2,8 @@ package com.simzoo.withmedical.entity;
 
 import static jakarta.persistence.FetchType.LAZY;
 
-import com.simzoo.withmedical.dto.MemberResponseDto;
-import com.simzoo.withmedical.dto.UpdateMemberRequestDto;
+import com.simzoo.withmedical.dto.member.MemberResponseDto;
+import com.simzoo.withmedical.dto.member.UpdateMemberRequestDto;
 import com.simzoo.withmedical.entity.chat.ChatRoomMember;
 import com.simzoo.withmedical.enums.Gender;
 import com.simzoo.withmedical.enums.Role;
@@ -33,6 +33,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 import org.hibernate.envers.AuditOverride;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
 @Entity(name = "member")
 @Getter
@@ -54,6 +55,7 @@ public class MemberEntity extends BaseEntity {
     private String password;
     private String passwordConfirm;
     private LocalDateTime lastLogin;
+    private LocalDateTime passwordChangedAt;
 
     @Enumerated(EnumType.STRING)
     @ElementCollection(fetch = LAZY)
@@ -133,6 +135,11 @@ public class MemberEntity extends BaseEntity {
     public void updateInfo(UpdateMemberRequestDto requestDto) {
         updateIfNotNull(requestDto.getNickname(), nickname -> this.nickname = nickname);
         updateIfNotNull(requestDto.getGender(), gender -> this.gender = gender);
+    }
+
+    public void changePassword(String newPassword, PasswordEncoder passwordEncoder) {
+        this.password = passwordEncoder.encode(newPassword);
+        this.passwordChangedAt = LocalDateTime.now();
     }
 
     private <T> void updateIfNotNull(T value, Consumer<T> setter) {

--- a/backend/src/main/java/com/simzoo/withmedical/entity/TuteeProfileEntity.java
+++ b/backend/src/main/java/com/simzoo/withmedical/entity/TuteeProfileEntity.java
@@ -1,6 +1,6 @@
 package com.simzoo.withmedical.entity;
 
-import com.simzoo.withmedical.dto.UpdateMemberRequestDto.UpdateTuteeProfileRequestDto;
+import com.simzoo.withmedical.dto.member.UpdateMemberRequestDto.UpdateTuteeProfileRequestDto;
 import com.simzoo.withmedical.dto.tutee.TuteeProfileResponseDto;
 import com.simzoo.withmedical.enums.Gender;
 import com.simzoo.withmedical.enums.Location;

--- a/backend/src/main/java/com/simzoo/withmedical/entity/TutorProfileEntity.java
+++ b/backend/src/main/java/com/simzoo/withmedical/entity/TutorProfileEntity.java
@@ -1,6 +1,6 @@
 package com.simzoo.withmedical.entity;
 
-import com.simzoo.withmedical.dto.UpdateMemberRequestDto.UpdateTutorProfileRequestDto;
+import com.simzoo.withmedical.dto.member.UpdateMemberRequestDto.UpdateTutorProfileRequestDto;
 import com.simzoo.withmedical.dto.tutor.TutorProfileResponseDto;
 import com.simzoo.withmedical.enums.EnrollmentStatus;
 import com.simzoo.withmedical.enums.Location;

--- a/backend/src/main/java/com/simzoo/withmedical/service/AuthService.java
+++ b/backend/src/main/java/com/simzoo/withmedical/service/AuthService.java
@@ -2,6 +2,7 @@ package com.simzoo.withmedical.service;
 
 import com.simzoo.withmedical.dto.auth.JwtResponseDto;
 import com.simzoo.withmedical.dto.auth.LoginRequestDto;
+import com.simzoo.withmedical.dto.member.ChangePasswordDto;
 import com.simzoo.withmedical.entity.MemberEntity;
 import com.simzoo.withmedical.exception.CustomException;
 import com.simzoo.withmedical.exception.ErrorCode;
@@ -41,6 +42,19 @@ public class AuthService {
         return JwtResponseDto.builder().accessToken(
             jwtUtil.generateAccessToken(memberEntity.getNickname(), memberEntity.getId(),
                 requestDto.getRole())).build();
+    }
+
+    @Transactional
+    public void changeMyPassword(Long userId, ChangePasswordDto requestDto) {
+
+        MemberEntity memberEntity = memberRepository.findById(userId)
+            .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_USER));
+
+        if (notMatchPassword(memberEntity, requestDto.getOldPassword(), passwordEncoder)) {
+            throw new CustomException(ErrorCode.NOT_MATCH_PASSWORD);
+        }
+
+        memberEntity.changePassword(requestDto.getNewPassword(), passwordEncoder);
     }
 
     private static boolean notMatchPassword(MemberEntity member, String password,

--- a/backend/src/main/java/com/simzoo/withmedical/service/MemberService.java
+++ b/backend/src/main/java/com/simzoo/withmedical/service/MemberService.java
@@ -1,8 +1,8 @@
 package com.simzoo.withmedical.service;
 
-import com.simzoo.withmedical.dto.UpdateMemberRequestDto;
-import com.simzoo.withmedical.dto.UpdateMemberRequestDto.UpdateTuteeProfileRequestDto;
-import com.simzoo.withmedical.dto.UpdateMemberRequestDto.UpdateTutorProfileRequestDto;
+import com.simzoo.withmedical.dto.member.UpdateMemberRequestDto;
+import com.simzoo.withmedical.dto.member.UpdateMemberRequestDto.UpdateTuteeProfileRequestDto;
+import com.simzoo.withmedical.dto.member.UpdateMemberRequestDto.UpdateTutorProfileRequestDto;
 import com.simzoo.withmedical.dto.tutee.TuteeProfileRequestDto;
 import com.simzoo.withmedical.entity.MemberEntity;
 import com.simzoo.withmedical.entity.SubjectEntity;
@@ -15,8 +15,11 @@ import com.simzoo.withmedical.exception.ErrorCode;
 import com.simzoo.withmedical.repository.TuteeProfileRepository;
 import com.simzoo.withmedical.repository.member.MemberRepository;
 import com.simzoo.withmedical.repository.subject.SubjectRepository;
+import com.simzoo.withmedical.repository.tutor.TutorProfileRepository;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -31,6 +34,7 @@ public class MemberService {
     private final MemberRepository memberRepository;
     private final SubjectRepository subjectRepository;
     private final TuteeProfileRepository tuteeProfileRepository;
+    private final TutorProfileRepository tutorProfileRepository;
 
     @Transactional(readOnly = true)
     public void checkMemberExist(String phoneNumber) {
@@ -108,6 +112,34 @@ public class MemberService {
         MemberEntity memberEntity = memberRepository.findById(userId)
             .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_USER));
         memberEntity.removeTuteeProfile(tuteeProfile);
+    }
+
+    @Transactional
+    public void deleteMember(Long userId) {
+        MemberEntity memberEntity = memberRepository.findByIdWithProfile(userId)
+            .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_USER));
+
+        List<TuteeProfileEntity> tuteeProfiles = memberEntity.getTuteeProfiles();
+        TutorProfileEntity tutorProfile = memberEntity.getTutorProfile();
+
+        // 1. SubjectEntity 삭제
+        List<SubjectEntity> subjectsToDelete = new ArrayList<>();
+        Optional.ofNullable(tuteeProfiles).ifPresent(profiles ->
+            profiles.forEach(e -> subjectsToDelete.addAll(e.getSubjects()))
+        );
+        Optional.ofNullable(tutorProfile).ifPresent(profile ->
+            subjectsToDelete.addAll(profile.getSubjects())
+        );
+        subjectRepository.deleteAll(subjectsToDelete);
+
+        // 2. TuteeProfileEntity 삭제
+        Optional.ofNullable(tuteeProfiles).ifPresent(tuteeProfileRepository::deleteAll);
+
+        // 3. TutorProfileEntity 삭제
+        Optional.ofNullable(tutorProfile).ifPresent(tutorProfileRepository::delete);
+
+        // 4. MemberEntity 삭제
+        memberRepository.delete(memberEntity);
     }
 
     private void updateTutorSubjectAndProfile(MemberEntity member,

--- a/backend/src/test/java/com/simzoo/withmedical/service/AuthServiceTest.java
+++ b/backend/src/test/java/com/simzoo/withmedical/service/AuthServiceTest.java
@@ -1,0 +1,59 @@
+package com.simzoo.withmedical.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+
+import com.simzoo.withmedical.dto.member.ChangePasswordDto;
+import com.simzoo.withmedical.entity.MemberEntity;
+import com.simzoo.withmedical.repository.member.MemberRepository;
+import com.simzoo.withmedical.util.JwtUtil;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@ExtendWith(MockitoExtension.class)
+class AuthServiceTest {
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @Mock
+    private PasswordEncoder passwordEncoder;
+
+    @Mock
+    private JwtUtil jwtUtil;
+
+    @InjectMocks
+    private AuthService authService;
+
+
+    @Test
+    void changePassword_success() {
+        //given
+        MemberEntity memberEntity = MemberEntity.builder()
+            .id(1L)
+            .nickname("nickname")
+            .password("encodedOldPassword")
+            .build();
+
+        ChangePasswordDto requestDto = ChangePasswordDto.builder()
+            .newPassword("newPassword")
+            .oldPassword("oldPassword")
+            .confirmPassword("newPassword")
+            .build();
+
+        when(memberRepository.findById(memberEntity.getId())).thenReturn(Optional.of(memberEntity));
+        when(passwordEncoder.matches(requestDto.getOldPassword(), memberEntity.getPassword())).thenReturn(true);
+        when(passwordEncoder.encode(requestDto.getNewPassword())).thenReturn("encodedPassword");
+        //when
+        authService.changeMyPassword(memberEntity.getId(), requestDto);
+
+        //then
+        assertEquals("encodedPassword", memberEntity.getPassword());
+    }
+
+}


### PR DESCRIPTION
### 이 PR을 통해 해결하려는 문제
- 회원 탈퇴 기능 추가
- 비밀번호 변경 추가

### 이 PR에서 변경된 사항
회원 탈퇴
- MemberController
- MemberService.deleteMember: 회원탈퇴 서비스 로직

비밀번호 변경
- MemberController.changePassword: PATCH /me/password
- AuthService.changeMyPassword 추가
- ChangePasswordDto: 비밀번호 변경 요청 dto
- MemberEntity
  - passwordChangedAt 필드 추가
  - changePassword() 메서드 추가

기타
- .gitignore: application-test.yml(test용 데이터베이스 설정)
- 회원관리 관련 dto 패키지 추가, class 이동, import 변경: MemberResponseDto, SignupController, TuteeProfileEntity, TutorProfileEntity, UpdateMemberRequestDto

테스트
- AuthServiceTest: 비밀번호 변경 로직 테스트
- MemberServiceDatabaseTest: 학생, 선생님 회원의 회원탈퇴 로직 테스트(데이터베이스 연동)

### 참고 스크린샷

### 기타
- 회원탈퇴 로직 구현 시 subject -> tutor / tutee -> member 각각 삭제 

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 -->
- [x] 테스트 코드
- [x] API 테스트
