### PR TITLE
feat-back-cancelAccount&passwordChange-002 회원탈퇴, 비밀번호 변경 수정

### DIFF
--- a/backend/src/main/java/com/simzoo/withmedical/controller/AuthController.java
+++ b/backend/src/main/java/com/simzoo/withmedical/controller/AuthController.java
@@ -2,13 +2,17 @@ package com.simzoo.withmedical.controller;
 
 import com.simzoo.withmedical.dto.auth.JwtResponseDto;
 import com.simzoo.withmedical.dto.auth.LoginRequestDto;
+import com.simzoo.withmedical.dto.member.ChangePasswordDto;
 import com.simzoo.withmedical.service.AuthService;
 import com.simzoo.withmedical.service.LogoutService;
 import com.simzoo.withmedical.service.MemberService;
 import com.simzoo.withmedical.service.VerificationService;
+import com.simzoo.withmedical.util.resolver.LoginId;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -44,6 +48,23 @@ public class AuthController {
     public ResponseEntity<?> logout(@RequestHeader(name = "Authorization") String token) {
 
         logoutService.logout(token);
+        return ResponseEntity.ok().build();
+    }
+
+    @DeleteMapping("/me")
+    public ResponseEntity<Void> cancelAccount(@LoginId Long userId, @RequestBody String password) {
+
+        authService.deleteMember(userId, password);
+
+        return ResponseEntity.ok().build();
+    }
+
+    @PatchMapping("/me/password")
+    public ResponseEntity<Void> changePassword(@LoginId Long userId,
+        @RequestBody ChangePasswordDto requestDto) {
+
+        authService.changeMyPassword(userId, requestDto);
+
         return ResponseEntity.ok().build();
     }
 }

--- a/backend/src/main/java/com/simzoo/withmedical/controller/MemberController.java
+++ b/backend/src/main/java/com/simzoo/withmedical/controller/MemberController.java
@@ -1,6 +1,5 @@
 package com.simzoo.withmedical.controller;
 
-import com.simzoo.withmedical.dto.member.ChangePasswordDto;
 import com.simzoo.withmedical.dto.member.MemberResponseDto;
 import com.simzoo.withmedical.dto.member.UpdateMemberRequestDto;
 import com.simzoo.withmedical.dto.tutee.TuteeProfileRequestDto;
@@ -14,7 +13,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -81,22 +79,5 @@ public class MemberController {
         memberService.removeProfile(userId, tuteeId);
 
         return ResponseEntity.ok().build();
-    }
-
-    @DeleteMapping("/me")
-    public ResponseEntity<Void> cancleAccount(@LoginId Long userId) {
-
-        memberService.deleteMember(userId);
-
-        return ResponseEntity.ok().build();
-    }
-
-    @PatchMapping("/me/password")
-    public ResponseEntity<?> changePassword(@LoginId Long userId,
-        @RequestBody ChangePasswordDto requestDto) {
-
-        authService.changeMyPassword(userId, requestDto);
-
-        return null;
     }
 }

--- a/backend/src/main/java/com/simzoo/withmedical/service/AuthService.java
+++ b/backend/src/main/java/com/simzoo/withmedical/service/AuthService.java
@@ -4,12 +4,21 @@ import com.simzoo.withmedical.dto.auth.JwtResponseDto;
 import com.simzoo.withmedical.dto.auth.LoginRequestDto;
 import com.simzoo.withmedical.dto.member.ChangePasswordDto;
 import com.simzoo.withmedical.entity.MemberEntity;
+import com.simzoo.withmedical.entity.SubjectEntity;
+import com.simzoo.withmedical.entity.TuteeProfileEntity;
+import com.simzoo.withmedical.entity.TutorProfileEntity;
 import com.simzoo.withmedical.exception.CustomException;
 import com.simzoo.withmedical.exception.ErrorCode;
+import com.simzoo.withmedical.repository.TuteeProfileRepository;
 import com.simzoo.withmedical.repository.member.MemberRepository;
+import com.simzoo.withmedical.repository.subject.SubjectRepository;
+import com.simzoo.withmedical.repository.tutor.TutorProfileRepository;
 import com.simzoo.withmedical.util.AesUtil;
 import com.simzoo.withmedical.util.JwtUtil;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -21,6 +30,9 @@ public class AuthService {
 
     private final MemberRepository memberRepository;
     private final PasswordEncoder passwordEncoder;
+    private final SubjectRepository subjectRepository;
+    private final TutorProfileRepository tutorProfileRepository;
+    private final TuteeProfileRepository tuteeProfileRepository;
     private final JwtUtil jwtUtil;
 
     @Transactional
@@ -56,6 +68,39 @@ public class AuthService {
 
         memberEntity.changePassword(requestDto.getNewPassword(), passwordEncoder);
     }
+
+    @Transactional
+    public void deleteMember(Long userId, String password) {
+        MemberEntity memberEntity = memberRepository.findByIdWithProfile(userId)
+            .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_USER));
+
+        if (notMatchPassword(memberEntity, password, passwordEncoder)) {
+            throw new CustomException(ErrorCode.NOT_MATCH_PASSWORD);
+        }
+
+        List<TuteeProfileEntity> tuteeProfiles = memberEntity.getTuteeProfiles();
+        TutorProfileEntity tutorProfile = memberEntity.getTutorProfile();
+
+        // 1. SubjectEntity 삭제
+        List<SubjectEntity> subjectsToDelete = new ArrayList<>();
+        Optional.ofNullable(tuteeProfiles).ifPresent(profiles ->
+            profiles.forEach(e -> subjectsToDelete.addAll(e.getSubjects()))
+        );
+        Optional.ofNullable(tutorProfile).ifPresent(profile ->
+            subjectsToDelete.addAll(profile.getSubjects())
+        );
+        subjectRepository.deleteAll(subjectsToDelete);
+
+        // 2. TuteeProfileEntity 삭제
+        Optional.ofNullable(tuteeProfiles).ifPresent(tuteeProfileRepository::deleteAll);
+
+        // 3. TutorProfileEntity 삭제
+        Optional.ofNullable(tutorProfile).ifPresent(tutorProfileRepository::delete);
+
+        // 4. MemberEntity 삭제
+        memberRepository.delete(memberEntity);
+    }
+
 
     private static boolean notMatchPassword(MemberEntity member, String password,
         PasswordEncoder passwordEncoder) {

--- a/backend/src/main/java/com/simzoo/withmedical/service/MemberService.java
+++ b/backend/src/main/java/com/simzoo/withmedical/service/MemberService.java
@@ -16,10 +16,8 @@ import com.simzoo.withmedical.repository.TuteeProfileRepository;
 import com.simzoo.withmedical.repository.member.MemberRepository;
 import com.simzoo.withmedical.repository.subject.SubjectRepository;
 import com.simzoo.withmedical.repository.tutor.TutorProfileRepository;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -112,34 +110,6 @@ public class MemberService {
         MemberEntity memberEntity = memberRepository.findById(userId)
             .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_USER));
         memberEntity.removeTuteeProfile(tuteeProfile);
-    }
-
-    @Transactional
-    public void deleteMember(Long userId) {
-        MemberEntity memberEntity = memberRepository.findByIdWithProfile(userId)
-            .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_USER));
-
-        List<TuteeProfileEntity> tuteeProfiles = memberEntity.getTuteeProfiles();
-        TutorProfileEntity tutorProfile = memberEntity.getTutorProfile();
-
-        // 1. SubjectEntity 삭제
-        List<SubjectEntity> subjectsToDelete = new ArrayList<>();
-        Optional.ofNullable(tuteeProfiles).ifPresent(profiles ->
-            profiles.forEach(e -> subjectsToDelete.addAll(e.getSubjects()))
-        );
-        Optional.ofNullable(tutorProfile).ifPresent(profile ->
-            subjectsToDelete.addAll(profile.getSubjects())
-        );
-        subjectRepository.deleteAll(subjectsToDelete);
-
-        // 2. TuteeProfileEntity 삭제
-        Optional.ofNullable(tuteeProfiles).ifPresent(tuteeProfileRepository::deleteAll);
-
-        // 3. TutorProfileEntity 삭제
-        Optional.ofNullable(tutorProfile).ifPresent(tutorProfileRepository::delete);
-
-        // 4. MemberEntity 삭제
-        memberRepository.delete(memberEntity);
     }
 
     private void updateTutorSubjectAndProfile(MemberEntity member,

--- a/backend/src/test/java/com/simzoo/withmedical/TestSecurityConfig.java
+++ b/backend/src/test/java/com/simzoo/withmedical/TestSecurityConfig.java
@@ -1,5 +1,6 @@
 package com.simzoo.withmedical;
 
+import com.simzoo.withmedical.util.JwtUtil;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
@@ -11,6 +12,11 @@ public class TestSecurityConfig {
     @Bean
     public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public JwtUtil jwtUtil() {
+        return new JwtUtil();
     }
 
 }

--- a/backend/src/test/java/com/simzoo/withmedical/service/AuthServiceDatabaseTest.java
+++ b/backend/src/test/java/com/simzoo/withmedical/service/AuthServiceDatabaseTest.java
@@ -1,0 +1,147 @@
+package com.simzoo.withmedical.service;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.simzoo.withmedical.TestSecurityConfig;
+import com.simzoo.withmedical.config.QueryDslConfig;
+import com.simzoo.withmedical.entity.MemberEntity;
+import com.simzoo.withmedical.entity.SubjectEntity;
+import com.simzoo.withmedical.entity.TuteeProfileEntity;
+import com.simzoo.withmedical.entity.TutorProfileEntity;
+import com.simzoo.withmedical.enums.Gender;
+import com.simzoo.withmedical.enums.Role;
+import com.simzoo.withmedical.enums.Subject;
+import com.simzoo.withmedical.repository.TuteeProfileRepository;
+import com.simzoo.withmedical.repository.member.MemberRepository;
+import com.simzoo.withmedical.repository.subject.SubjectRepository;
+import com.simzoo.withmedical.repository.tutor.TutorProfileRepository;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+@DataJpaTest
+@Import({AuthService.class, QueryDslConfig.class, TestSecurityConfig.class})
+@ActiveProfiles("test")
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class AuthServiceDatabaseTest {
+
+    @Autowired
+    private AuthService authService;
+
+    @Autowired
+    private TuteeProfileRepository tuteeProfileRepository;
+
+    @Autowired
+    private SubjectRepository subjectRepository;
+
+    @Autowired
+    private TutorProfileRepository tutorProfileRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+    @Qualifier("passwordEncoder")
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    @Test
+    @DisplayName("회원삭제 테스트_학생 회원")
+    @Transactional
+    void cancelAccount() {
+        //given
+        Role role = Role.TUTEE;
+
+        String password = "password";
+        String encodedPassword = passwordEncoder.encode(password);
+
+        TuteeProfileEntity tuteeProfile = TuteeProfileEntity.builder()
+            .name("tuteeName")
+            .gender(Gender.FEMALE)
+            .description("testDescription")
+            .subjects(new ArrayList<>())
+            .build();
+
+        TuteeProfileEntity savedTutee = tuteeProfileRepository.save(tuteeProfile);
+
+        SubjectEntity subject = SubjectEntity.builder()
+            .tuteeProfile(savedTutee)
+            .subject(Subject.ELEMENTARY_ENGLISH)
+            .build();
+
+        SubjectEntity savedSubject = subjectRepository.save(subject);
+
+        savedTutee.addSubject(List.of(savedSubject));
+
+        MemberEntity member = MemberEntity.builder()
+            .nickname("parent")
+            .gender(Gender.FEMALE)
+            .roles(List.of(role))
+            .password(encodedPassword)
+            .build();
+
+        MemberEntity savedMember = memberRepository.save(member);
+        savedMember.saveTuteeProfiles(List.of(savedTutee), role);
+
+        //when
+        authService.deleteMember(savedMember.getId(), password);
+
+        //then
+        assertTrue(memberRepository.findById(savedMember.getId()).isEmpty());
+        assertTrue(tuteeProfileRepository.findAll().isEmpty());
+        assertTrue(subjectRepository.findAll().isEmpty());
+    }
+
+    @Test
+    @DisplayName("회원삭제 테스트_선생님 회원")
+    @Transactional
+    void cancelAccount_Tutor() {
+        //given
+        Role role = Role.TUTOR;
+
+        String password = "password";
+        String encodedPassword = passwordEncoder.encode(password);
+        TutorProfileEntity tutorProfile = TutorProfileEntity.builder()
+            .imageUrl("testImage")
+            .description("testDescription")
+            .subjects(new ArrayList<>())
+            .build();
+
+        TutorProfileEntity savedTutor = tutorProfileRepository.save(tutorProfile);
+
+        SubjectEntity subject = SubjectEntity.builder()
+            .tutorProfile(savedTutor)
+            .subject(Subject.ELEMENTARY_ENGLISH)
+            .build();
+
+        SubjectEntity savedSubject = subjectRepository.save(subject);
+
+        savedTutor.addSubjects(List.of(savedSubject));
+
+        MemberEntity member = MemberEntity.builder()
+            .nickname("parent")
+            .gender(Gender.FEMALE)
+            .roles(List.of(role))
+            .password(encodedPassword)
+            .build();
+
+        MemberEntity savedMember = memberRepository.save(member);
+        savedMember.saveTutorProfile(savedTutor, role);
+
+        //when
+        authService.deleteMember(savedMember.getId(), password);
+
+        //then
+        assertTrue(memberRepository.findById(savedMember.getId()).isEmpty());
+        assertTrue(tutorProfileRepository.findAll().isEmpty());
+        assertTrue(subjectRepository.findAll().isEmpty());
+    }
+
+}

--- a/backend/src/test/java/com/simzoo/withmedical/service/MemberServiceDatabaseTest.java
+++ b/backend/src/test/java/com/simzoo/withmedical/service/MemberServiceDatabaseTest.java
@@ -1,7 +1,6 @@
 package com.simzoo.withmedical.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.simzoo.withmedical.config.QueryDslConfig;
 import com.simzoo.withmedical.dto.member.UpdateMemberRequestDto;
@@ -10,7 +9,6 @@ import com.simzoo.withmedical.dto.tutee.TuteeProfileRequestDto;
 import com.simzoo.withmedical.entity.MemberEntity;
 import com.simzoo.withmedical.entity.SubjectEntity;
 import com.simzoo.withmedical.entity.TuteeProfileEntity;
-import com.simzoo.withmedical.entity.TutorProfileEntity;
 import com.simzoo.withmedical.enums.Gender;
 import com.simzoo.withmedical.enums.Role;
 import com.simzoo.withmedical.enums.Subject;
@@ -174,90 +172,4 @@ class  MemberServiceDatabaseTest {
             result.getTuteeProfiles().get(0).getSubjects().get(0).getSubject());
         assertEquals("updatedTuteeName", result.getTuteeProfiles().get(0).getName());
     }
-
-    @Test
-    @DisplayName("회원삭제 테스트_학생 회원")
-    @Transactional
-    void cancleAccount() {
-        //given
-        Role role = Role.TUTEE;
-
-        TuteeProfileEntity tuteeProfile = TuteeProfileEntity.builder()
-            .name("tuteeName")
-            .gender(Gender.FEMALE)
-            .description("testDescription")
-            .subjects(new ArrayList<>())
-            .build();
-
-        TuteeProfileEntity savedTutee = tuteeProfileRepository.save(tuteeProfile);
-
-        SubjectEntity subject = SubjectEntity.builder()
-            .tuteeProfile(savedTutee)
-            .subject(Subject.ELEMENTARY_ENGLISH)
-            .build();
-
-        SubjectEntity savedSubject = subjectRepository.save(subject);
-
-        savedTutee.addSubject(List.of(savedSubject));
-
-        MemberEntity member = MemberEntity.builder()
-            .nickname("parent")
-            .gender(Gender.FEMALE)
-            .roles(List.of(role))
-            .build();
-
-        MemberEntity savedMember = memberRepository.save(member);
-        savedMember.saveTuteeProfiles(List.of(savedTutee), role);
-
-        //when
-         memberService.deleteMember(savedMember.getId());
-
-        //then
-        assertTrue(memberRepository.findById(savedMember.getId()).isEmpty());
-        assertTrue(tuteeProfileRepository.findAll().isEmpty());
-        assertTrue(subjectRepository.findAll().isEmpty());
-    }
-
-    @Test
-    @DisplayName("회원삭제 테스트_선생님 회원")
-    @Transactional
-    void cancleAccount_Tutor() {
-        //given
-        Role role = Role.TUTOR;
-
-        TutorProfileEntity tutorProfile = TutorProfileEntity.builder()
-            .imageUrl("testImage")
-            .description("testDescription")
-            .subjects(new ArrayList<>())
-            .build();
-
-        TutorProfileEntity savedTutor = tutorProfileRepository.save(tutorProfile);
-
-        SubjectEntity subject = SubjectEntity.builder()
-            .tutorProfile(savedTutor)
-            .subject(Subject.ELEMENTARY_ENGLISH)
-            .build();
-
-        SubjectEntity savedSubject = subjectRepository.save(subject);
-
-        savedTutor.addSubjects(List.of(savedSubject));
-
-        MemberEntity member = MemberEntity.builder()
-            .nickname("parent")
-            .gender(Gender.FEMALE)
-            .roles(List.of(role))
-            .build();
-
-        MemberEntity savedMember = memberRepository.save(member);
-        savedMember.saveTutorProfile(savedTutor, role);
-
-        //when
-        memberService.deleteMember(savedMember.getId());
-
-        //then
-        assertTrue(memberRepository.findById(savedMember.getId()).isEmpty());
-        assertTrue(tutorProfileRepository.findAll().isEmpty());
-        assertTrue(subjectRepository.findAll().isEmpty());
-    }
-
 }


### PR DESCRIPTION


### 이 PR을 통해 해결하려는 문제
- 회원탈퇴 시 회원 비밀번호를 입력받도록 한다 

### 이 PR에서 변경된 사항
- 회원탈퇴 시 비밀번호 값 전달
- 회원탈퇴 및 비밀번호 변경 로직 AuthController 와 AuthService 에서 관리
- 테스트코드 수정

### 기타

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 -->
- [x] 테스트 코드
- [ ] API 테스트
