### PR TITLE
feat-front-auth-004 로그인 상태 유지

### DIFF
--- a/frontend/chat-frontend/src/App.js
+++ b/frontend/chat-frontend/src/App.js
@@ -22,68 +22,61 @@ import FixedHeader from './components/header/FixedHeader';
 import ProfileEdit from './components/profile/ProfileEdit';
 import Membership from './components/memberShip/MemberShip';
 import TuteePost from './components/tuteePost/TuteePost';
-import { AuthProvider } from './components/context/AuthContext';
+import { useAuth } from './components/context/AuthProvider';
 
-const App = () => {
-    const [roomId, setRoomId] = useState(null);
+const AppContent = () => {
+
     const [recipientId, setRecipientId] = useState(null);  // recipientId 저장
     const [memberId, setMemberId] = useState(null);
     const [memberNickname, setMemberNickname] = useState('Tutor1');
     const [memberRole, setMemberRole] = useState(null);
-    const [isLoggedIn, setIsLoggedIn] = useState(false); // 로그인 상태 관리
+    const { isLoading } = useAuth();
 
-    const handleLogin = (role) => {
-        setIsLoggedIn(true);
-        setMemberRole(role);
-        setMemberId(memberId);
-    } // 로그인 성공 시 호출
-
-    const handleLogout = () => {
-        setIsLoggedIn(false); // 로그아웃 시 호출
-        setMemberRole(null);
-        setMemberId(null)
-    }
-
-    const handleRoomSelect = (selectedRoomId, selectedRecipientId) => {
-        setRoomId(selectedRoomId);
-        setRecipientId(selectedRecipientId);
+    if (isLoading) {
+        return <div>Loading...</div>; // 초기화 중 표시
     }
 
     return (
-        <AuthProvider>
-        <Router>
+        <>
             <FixedHeader />
-                    {/* 라우팅 설정 */}
-                    <Routes>
-                        <Route path="/" element={<MainContentWrapper><Home /></MainContentWrapper>} />
-                        <Route path="/login" element={<MainContentWrapper><Login onLogin={handleLogin} /></MainContentWrapper>} />
-                        <Route path="/signup" element={<MainContentWrapper><Signup /></MainContentWrapper>} />
-                        <Route path="/posting-form" element={<MainContentWrapper><PostingForm /></MainContentWrapper>} />
-                        <Route path="/posts" element={<MainContentWrapper><TuteePostList memberId={memberId} memberRole={memberRole}/></MainContentWrapper>}/>
-                        <Route path="/tutee/post/:postingId" element={<MainContentWrapper><TuteePost /></MainContentWrapper>} />
-                        <Route path="/tutor-profiles" element={<MainContentWrapper><TutorList /></MainContentWrapper>} />
-                        <Route path="/tutor-profiles/:tutorId" element={<MainContentWrapper><TutorProfile/></MainContentWrapper>}/>
+            {/* 라우팅 설정 */}
+            <Routes>
+                <Route path="/" element={<MainContentWrapper><Home /></MainContentWrapper>} />
+                <Route path="/login" element={<MainContentWrapper><Login /></MainContentWrapper>} />
+                <Route path="/signup" element={<MainContentWrapper><Signup /></MainContentWrapper>} />
+                <Route path="/posting-form" element={<MainContentWrapper><PostingForm /></MainContentWrapper>} />
+                <Route path="/posts" element={<MainContentWrapper><TuteePostList memberId={memberId} memberRole={memberRole}/></MainContentWrapper>}/>
+                <Route path="/tutee/post/:postingId" element={<MainContentWrapper><TuteePost /></MainContentWrapper>} />
+                <Route path="/tutor-profiles" element={<MainContentWrapper><TutorList /></MainContentWrapper>} />
+                <Route path="/tutor-profiles/:tutorId" element={<MainContentWrapper><TutorProfile/></MainContentWrapper>}/>
 
-                        {/* MyProfile 내부 라우트 설정 */}
-                        <Route path="/me" element={<ProfileLayout />}>
-                            <Route path="my-posts" element={<MyPosts />} />\
-                            <Route path="edit-post/:postingId" element={<EditTuteePostForm />} /> {/* 추가된 라우트 */}
-                            <Route path="profile" element={<ProfileInfo />} />
-                            <Route path="profile/edit" element={<ProfileEdit />} />
-                            <Route path="chatrooms" element={<ChatRoomList />} />
-                            <Route path="delete-account" element={<DeleteAccount />} />
-                            <Route path="change-password" element={<ChangePassword />} />
-                            <Route path="membership" element={<Membership />} />
-                        </Route>
-                        
-                        
-                        {/* Chat Layout */}
-                        <Route path="/chatrooms" element={<ChatLayout />}>
-                            <Route path=":roomId" element={<ChatRoom memberId={memberId} memberNickname={memberNickname} memberRole={memberRole} recipientId={recipientId}/>}/>
-                        </Route>
-                    </Routes>
+                {/* MyProfile 내부 라우트 설정 */}
+                <Route path="/me" element={<ProfileLayout />}>
+                    <Route path="my-posts" element={<MyPosts />} />\
+                    <Route path="edit-post/:postingId" element={<EditTuteePostForm />} /> {/* 추가된 라우트 */}
+                    <Route path="profile" element={<ProfileInfo />} />
+                    <Route path="profile/edit" element={<ProfileEdit />} />
+                    <Route path="chatrooms" element={<ChatRoomList />} />
+                    <Route path="delete-account" element={<DeleteAccount />} />
+                    <Route path="change-password" element={<ChangePassword />} />
+                    <Route path="membership" element={<Membership />} />
+                </Route>
+                
+                
+                {/* Chat Layout */}
+                <Route path="/chatrooms" element={<ChatLayout />}>
+                    <Route path=":roomId" element={<ChatRoom memberId={memberId} memberNickname={memberNickname} memberRole={memberRole} recipientId={recipientId}/>}/>
+                </Route>
+            </Routes>
+        </>
+    );
+}
+
+const App = () => {
+    return (
+        <Router>
+            <AppContent />
         </Router>
-        </AuthProvider>
     );
 };
 

--- a/frontend/chat-frontend/src/components/context/AuthProvider.js
+++ b/frontend/chat-frontend/src/components/context/AuthProvider.js
@@ -1,0 +1,84 @@
+import React, { createContext, useContext, useEffect, useState } from 'react';
+
+const AuthContext = createContext();
+
+const AuthProvider = ({ children }) => {
+    console.log('AuthProvider Rendered')
+
+    const [isLoggedIn, setIsLoggedIn] = useState(false);
+    const [user, setUser] = useState(null); // 사용자 정보 저장
+    const [role, setRole] = useState(null);
+    const [isLoading, setIsLoading] = useState(true);
+
+    useEffect(() => {
+        console.log('AuthProvider useEffect 호출')
+        const token = localStorage.getItem('jwtToken');
+
+        if (token) {
+            const decodedUser = parseJwt(token);
+            console.log('decodedUser: ', decodedUser)
+
+            // 토큰 유효성 검증
+            if (decodedUser && isTokenValid(token)) {
+                setIsLoggedIn(true);
+                setUser(decodedUser);
+            } else {
+                localStorage.removeItem('jwtToken'); // 유효하지 않은 토큰 제거
+            }
+        }
+        setIsLoading(false);
+    }, []);
+
+    const login = (userData, token, role) => {
+        localStorage.setItem('jwtToken', token);
+        setIsLoggedIn(true);
+        setUser(userData);
+        setRole(role);
+    };
+
+    const logout = () => {
+        localStorage.removeItem('jwtToken');
+        setIsLoggedIn(false);
+        setRole(null);
+    };
+
+    return (
+        <AuthContext.Provider value={{ isLoggedIn, user, role, login, logout, isLoading }}>
+            {children}
+        </AuthContext.Provider>
+    );    
+};
+
+export default AuthProvider;
+
+export const useAuth = () => {
+    const context = useContext(AuthContext);
+    if (!context) {
+        throw new Error('useAuth must be used within an AuthProvider');
+    }
+    return context;
+};
+
+const parseJwt = (token) => {
+    try {
+        const base64Payload = token.split('.')[1];
+        const payload = atob(base64Payload);
+        return JSON.parse(payload);
+    } catch (e) {
+        console.error('Failed to parse JWT:', e);
+        return null;
+    }
+};
+
+const isTokenValid = (token) => {
+    try {
+        const decoded = parseJwt(token);
+        if (!decoded) return false;
+
+        const now = Math.floor(Date.now() / 1000); // 현재 시간 (초 단위)
+        return decoded.exp > now; // 토큰 만료 시간 확인
+    } catch (e) {
+        console.error('Invalid token:', e);
+        return false;
+    }
+};

--- a/frontend/chat-frontend/src/components/header/FixedHeader.js
+++ b/frontend/chat-frontend/src/components/header/FixedHeader.js
@@ -1,15 +1,22 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
+import { useAuth } from '../context/AuthProvider';
 import './FixedHeader.css';
 
-const FixedHeader = ({ isLoggedIn, onLogout }) => {
+const FixedHeader = () => {
+    const { isLoggedIn, logout, isLoading } = useAuth();
+
+    if (isLoading) {
+        return null; // 로딩 중에는 아무것도 렌더링하지 않음
+    }
+
     return (
         <header className="fixed-header">
             <div className="auth-buttons">
                 {isLoggedIn ? (
                     <>
                         <Link to="/me" className="auth-link">내 정보</Link>
-                        <button onClick={onLogout} className="auth-link">로그아웃</button>
+                        <button onClick={logout} className="auth-link">로그아웃</button>
                     </>
                 ) : (
                     <>
@@ -18,11 +25,9 @@ const FixedHeader = ({ isLoggedIn, onLogout }) => {
                     </>
                 )}
             </div>
-            
             <Link to="/" className="linkStyle">
                 <h1>의대생과 과외하기</h1>
             </Link>
-            
         </header>
     );
 };

--- a/frontend/chat-frontend/src/components/login/Login.js
+++ b/frontend/chat-frontend/src/components/login/Login.js
@@ -1,14 +1,16 @@
 import React, { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useAsyncValue, useNavigate } from 'react-router-dom';
 import axios from 'axios';
+import { useAuth } from '../context/AuthProvider';
 import './Login.css';
 
-const Login = ({ onLogin }) => {
+const Login = () => {
     const [phoneNumber, setPhoneNumber] = useState('');
     const [password, setPassword] = useState('');
     const [role, setRole] = useState(''); // 추가된 역할 상태
     const [error, setError] = useState('');
     const navigate = useNavigate(); // 리다이렉션을 위한 useNavigate 훅 사용
+    const { login } = useAuth();
 
     // Handle login with phone number and password
     const handleLoginSubmit = async (e) => {
@@ -25,10 +27,9 @@ const Login = ({ onLogin }) => {
             });
             const token = response.data.accessToken;
             localStorage.setItem('jwtToken', token);
-            onLogin(role); // 로그인 성공 시 App.js의 로그인 상태 업데이트
+            login(role, token)
             console.log("Logged in successfully with phone number and password.");
-            navigate('/'); // 로그인 성공 시 /home 경로로 이동
-            // Redirect or further action after successful login
+            navigate('/');
         } catch (err) {
             setError('Failed to log in. Please check your phone number and password and try again.');
             console.error(err);

--- a/frontend/chat-frontend/src/index.js
+++ b/frontend/chat-frontend/src/index.js
@@ -3,11 +3,14 @@ import ReactDOM from 'react-dom/client';
 import './index.css';
 import App from './App';
 import reportWebVitals from './reportWebVitals';
+import AuthProvider from './components/context/AuthProvider';
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
   // <React.StrictMode>
+  <AuthProvider>
     <App />
+  </AuthProvider>
   // {/* </React.StrictMode> */}
 );
 


### PR DESCRIPTION

### 이 PR을 통해 해결하려는 문제
- 새로고침 시 로그인 상태 유지되도록 구현
- TuteePost.js 컴포넌트 렌더링 시 로그인 상태 해지되는 버그 해결

### 이 PR에서 변경된 사항
### Front
- AuthProvider.js가 루트 컴포넌트를 감싸도록 설정 : index.js, App.js
- 렌더링 시, 로그인 시 발급받은 토큰을 가져와 로그인 상태를 검증하도록 설정 : AuthProvider.js
- 로딩 상태를 추가적으로 관리 : FixedHeader.js
- 링크 호출이 아니라 navigate를 통해 컴포넌트를 이동하도록 수정 : TuteePostList.js ( + InquiryButton 컴포넌트 적용)
- 로그인 시 AuthProvider의 login 메서드를 호출하도록 수정 : Login.js


### 참고 스크린샷

### 기타

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 -->
- [ ] 테스트 코드
- [ ] API 테스트
