### PR TITLE
feat-back-tutor-003 튜터 목록 조회 시 필터링값 적용(수정 및 추가)

### DIFF
--- a/backend/src/main/java/com/simzoo/withmedical/controller/TutorProfileController.java
+++ b/backend/src/main/java/com/simzoo/withmedical/controller/TutorProfileController.java
@@ -3,7 +3,16 @@ package com.simzoo.withmedical.controller;
 import com.simzoo.withmedical.dto.TutorSimpleResponseDto;
 import com.simzoo.withmedical.dto.filter.TutorFilterRequestDto;
 import com.simzoo.withmedical.dto.tutor.TutorProfileResponseDto;
+import com.simzoo.withmedical.enums.EnrollmentStatus;
+import com.simzoo.withmedical.enums.Gender;
+import com.simzoo.withmedical.enums.Location;
+import com.simzoo.withmedical.enums.Subject;
+import com.simzoo.withmedical.enums.University;
 import com.simzoo.withmedical.service.TutorProfileService;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -31,7 +40,15 @@ public class TutorProfileController {
         @ModelAttribute TutorFilterRequestDto filterRequest,
         @PageableDefault(page = 0, size = 10, direction = Direction.ASC, sort = "createdAt") Pageable pageable) {
 
-        return ResponseEntity.ok(tutorProfileService.getTutorList(pageable, filterRequest));
+        TutorFilterRequestDto.TutorEnumFilter filter = TutorFilterRequestDto.TutorEnumFilter.builder()
+            .gender(filterRequest.convertGender(filterRequest.getGender()))
+            .subjects(filterRequest.convertSubjects(filterRequest.getSubjects()))
+            .locations(filterRequest.convertLocations(filterRequest.getLocations()))
+            .universities(filterRequest.convertUniversity(filterRequest.getUniversities()))
+            .statusList(filterRequest.convertEnrollmentStatus(filterRequest.getStatusList()))
+            .build();
+
+        return ResponseEntity.ok(tutorProfileService.getTutorList(pageable, filter));
     }
 
     /**
@@ -40,5 +57,22 @@ public class TutorProfileController {
     @GetMapping("/{tutorId}")
     public ResponseEntity<TutorProfileResponseDto> getTutorProfile(@PathVariable Long tutorId) {
         return ResponseEntity.ok(tutorProfileService.getTutorDetail(tutorId));
+    }
+
+    /**
+     * 선생님 조회 필터요청값 불러오기
+     */
+    @GetMapping("/filters")
+    public ResponseEntity<Map<String, List<String>>> getFilters() {
+
+        Map<String, List<String>> filters = new HashMap<>();
+
+        filters.put("subjects", Arrays.stream(Subject.values()).map(Subject::getDescription).toList());
+        filters.put("locations", Arrays.stream(Location.values()).map(Location::getDescription).toList());
+        filters.put("universities", Arrays.stream(University.values()).map(University::getDescription).toList());
+        filters.put("statusList", Arrays.stream(EnrollmentStatus.values()).map(EnrollmentStatus::getDescription).toList());
+        filters.put("gender", Arrays.stream(Gender.values()).map(Gender::getDescription).toList());
+
+        return ResponseEntity.ok(filters);
     }
 }

--- a/backend/src/main/java/com/simzoo/withmedical/dto/filter/TutorFilterRequestDto.java
+++ b/backend/src/main/java/com/simzoo/withmedical/dto/filter/TutorFilterRequestDto.java
@@ -12,9 +12,66 @@ import lombok.Getter;
 @Getter
 @Builder
 public class TutorFilterRequestDto {
-    Gender gender;
-    List<Subject> subjects;
-    List<Location> locations;
-    List<University> universities;
-    List<EnrollmentStatus> statusList;
+    String gender;
+    List<String> subjects;
+    List<String> locations;
+    List<String> universities;
+    List<String> statusList;
+
+    @Builder
+    @Getter
+    public static class TutorEnumFilter {
+        Gender gender;
+        List<Subject> subjects;
+        List<Location> locations;
+        List<University> universities;
+        List<EnrollmentStatus> statusList;
+    }
+
+    public Gender convertGender(String gender) {
+        if (gender == null || gender.isEmpty()) {
+            return null;
+        }
+        return Gender.fromDescription(gender);
+    }
+
+    public List<Subject> convertSubjects(List<String> subjectNames) {
+        if (subjectNames == null || subjectNames.isEmpty()) {
+            return null;
+        }
+
+        return subjectNames.stream()
+            .map(Subject::fromDescription)
+            .toList();
+    }
+
+    public List<Location> convertLocations(List<String> locations) {
+        if (locations == null || locations.isEmpty()) {
+            return null;
+        }
+
+        return locations.stream()
+            .map(Location::fromDescription)
+            .toList();
+    }
+
+    public List<University> convertUniversity(List<String> universities) {
+        if (universities == null || universities.isEmpty()) {
+            return null;
+        }
+
+        return universities.stream()
+            .map(University::fromDescription)
+            .toList();
+    }
+
+    public List<EnrollmentStatus> convertEnrollmentStatus(List<String> statusList) {
+        if (statusList == null || statusList.isEmpty()) {
+            return null;
+        }
+
+        return statusList.stream()
+            .map(EnrollmentStatus::fromDescription)
+            .toList();
+    }
 }

--- a/backend/src/main/java/com/simzoo/withmedical/enums/EnrollmentStatus.java
+++ b/backend/src/main/java/com/simzoo/withmedical/enums/EnrollmentStatus.java
@@ -1,5 +1,8 @@
 package com.simzoo.withmedical.enums;
 
+import com.simzoo.withmedical.exception.CustomException;
+import com.simzoo.withmedical.exception.ErrorCode;
+import java.util.Arrays;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -12,4 +15,11 @@ public enum EnrollmentStatus {
     DROPPED_OUT("중퇴");
 
     private final String description;
+
+    public static EnrollmentStatus fromDescription(String description) {
+        return Arrays.stream(values())
+            .filter(status -> status.getDescription().equals(description))
+            .findFirst()
+            .orElseThrow(() -> new CustomException(ErrorCode.INVALID_DATA_REQUEST));
+    }
 }

--- a/backend/src/main/java/com/simzoo/withmedical/enums/Gender.java
+++ b/backend/src/main/java/com/simzoo/withmedical/enums/Gender.java
@@ -1,11 +1,23 @@
 package com.simzoo.withmedical.enums;
 
+import com.simzoo.withmedical.exception.CustomException;
+import com.simzoo.withmedical.exception.ErrorCode;
+import java.util.Arrays;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
 public enum Gender {
-    MALE,
-    FEMALE
+    MALE("남성"),
+    FEMALE("여성");
+
+    private final String description;
+
+    public static Gender fromDescription(String description) {
+        return Arrays.stream(values())
+            .filter(e -> e.description.equals(description))
+            .findFirst()
+            .orElseThrow(() -> new CustomException(ErrorCode.INVALID_DATA_REQUEST));
+    }
 }

--- a/backend/src/main/java/com/simzoo/withmedical/enums/Location.java
+++ b/backend/src/main/java/com/simzoo/withmedical/enums/Location.java
@@ -1,5 +1,8 @@
 package com.simzoo.withmedical.enums;
 
+import com.simzoo.withmedical.exception.CustomException;
+import com.simzoo.withmedical.exception.ErrorCode;
+import java.util.Arrays;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -11,4 +14,11 @@ public enum Location {
     BUSAN("부산");
 
     private final String description;
+
+    public static Location fromDescription(String description) {
+        return Arrays.stream(values())
+            .filter(e -> e.getDescription().equals(description))
+            .findFirst()
+            .orElseThrow(() -> new CustomException(ErrorCode.INVALID_DATA_REQUEST));
+    }
 }

--- a/backend/src/main/java/com/simzoo/withmedical/enums/Subject.java
+++ b/backend/src/main/java/com/simzoo/withmedical/enums/Subject.java
@@ -1,5 +1,8 @@
 package com.simzoo.withmedical.enums;
 
+import com.simzoo.withmedical.exception.CustomException;
+import com.simzoo.withmedical.exception.ErrorCode;
+import java.util.Arrays;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -14,4 +17,11 @@ public enum Subject {
     HIGH_ENGLISH("고등영어");
 
     private final String description;
+
+    public static Subject fromDescription(String description) {
+        return Arrays.stream(values())
+            .filter(e -> e.getDescription().equals(description))
+            .findFirst()
+            .orElseThrow(() -> new CustomException(ErrorCode.INVALID_DATA_REQUEST));
+    }
 }

--- a/backend/src/main/java/com/simzoo/withmedical/enums/University.java
+++ b/backend/src/main/java/com/simzoo/withmedical/enums/University.java
@@ -1,5 +1,8 @@
 package com.simzoo.withmedical.enums;
 
+import com.simzoo.withmedical.exception.CustomException;
+import com.simzoo.withmedical.exception.ErrorCode;
+import java.util.Arrays;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -12,4 +15,11 @@ public enum University {
     SUNKYUNKWAN_UNIVERSITY("성균관대학교");
 
     private final String description;
+
+    public static University fromDescription(String description) {
+        return Arrays.stream(values())
+            .filter(e -> e.getDescription().equals(description))
+            .findFirst()
+            .orElseThrow(() -> new CustomException(ErrorCode.INVALID_DATA_REQUEST));
+    }
 }

--- a/backend/src/main/java/com/simzoo/withmedical/exception/ErrorCode.java
+++ b/backend/src/main/java/com/simzoo/withmedical/exception/ErrorCode.java
@@ -27,7 +27,8 @@ public enum ErrorCode {
     NOT_MATCH_PASSWORD(HttpStatus.BAD_REQUEST, "비밀번호가 일치하지 않습니다."),
     ALREADY_EXIST_REVIEW(HttpStatus.UNAUTHORIZED, "이미 작성한 리뷰가 있습니다."),
     TUTEE_PROFILE_CANNOT_EXCEED_ONE_PROFILE(HttpStatus.BAD_REQUEST, "학생은 프로필을 2개 이상 가질 수 없습니다."),
-    INVALID_DATA(HttpStatus.INTERNAL_SERVER_ERROR, "유효하지 않은 데이터입니다.");
+    INVALID_DATA(HttpStatus.INTERNAL_SERVER_ERROR, "유효하지 않은 데이터입니다."),
+    INVALID_DATA_REQUEST(HttpStatus.BAD_REQUEST, "유효하지 않는 데이터 요청입니다.");
 
     private HttpStatus httpStatus;
     private String message;

--- a/backend/src/main/java/com/simzoo/withmedical/repository/tutor/TutorProfileRepositoryCustom.java
+++ b/backend/src/main/java/com/simzoo/withmedical/repository/tutor/TutorProfileRepositoryCustom.java
@@ -9,9 +9,9 @@ import org.springframework.data.domain.Pageable;
 
 public interface TutorProfileRepositoryCustom {
 
-    Long countFilteredProfiles(TutorFilterRequestDto filterRequestDto);
+    Long countFilteredProfiles(TutorFilterRequestDto.TutorEnumFilter filterRequestDto);
 
-    Page<TutorSimpleResponseDto> findFilteredProfiles(TutorFilterRequestDto filterRequestDto, Pageable pageable);
+    Page<TutorSimpleResponseDto> findFilteredProfiles(TutorFilterRequestDto.TutorEnumFilter filterRequestDto, Pageable pageable);
 
     Optional<TutorProfileResponseDto> findTutorProfileDtoById(Long id);
 }

--- a/backend/src/main/java/com/simzoo/withmedical/service/TutorProfileService.java
+++ b/backend/src/main/java/com/simzoo/withmedical/service/TutorProfileService.java
@@ -24,7 +24,7 @@ public class TutorProfileService {
      */
     @Transactional(readOnly = true)
     public Page<TutorSimpleResponseDto> getTutorList(Pageable pageable,
-        TutorFilterRequestDto filterRequest) {
+        TutorFilterRequestDto.TutorEnumFilter filterRequest) {
         return tutorProfileJdbcRepository.findFilteredProfiles(filterRequest, pageable);
     }
 

--- a/backend/src/test/java/com/simzoo/withmedical/service/TutorProfileServiceDatabaseTest.java
+++ b/backend/src/test/java/com/simzoo/withmedical/service/TutorProfileServiceDatabaseTest.java
@@ -116,21 +116,6 @@ class TutorProfileServiceDatabaseTest {
         System.out.println("tutor1 subjects = " + tutorProfileRepository.findById(tutor1.getId()).get().getSubjects());
         System.out.println("tutor2 subjects = " + tutorProfileRepository.findById(tutor2.getId()).get().getSubjects());
 
-        //given
-        Pageable pageable = PageRequest.of(0, 10, Direction.ASC, "createdAt");
-        TutorFilterRequestDto filterRequest = TutorFilterRequestDto.builder()
-//            .gender(Gender.MALE)
-//            .subjects(List.of(Subject.ELEMENTARY_ENGLISH, Subject.MIDDLE_ENGLISH))
-//            .locations(new ArrayList<>())
-//            .universities(new ArrayList<>())
-//            .statusList(new ArrayList<>())
-            .gender(null)
-            .subjects(null)
-            .locations(null)
-            .universities(null)
-            .statusList(null)
-            .build();
-
         //Debug
         // LEFT JOIN 결과 확인 쿼리
         String debugSql = """
@@ -163,6 +148,22 @@ class TutorProfileServiceDatabaseTest {
         results.forEach(result -> {
             System.out.println("Result Row: " + result);
         });
+
+        //given
+        Pageable pageable = PageRequest.of(0, 10, Direction.ASC, "createdAt");
+        TutorFilterRequestDto.TutorEnumFilter filterRequest = TutorFilterRequestDto.TutorEnumFilter.builder()
+//            .gender(Gender.MALE)
+//            .subjects(List.of(Subject.ELEMENTARY_ENGLISH, Subject.MIDDLE_ENGLISH))
+//            .locations(new ArrayList<>())
+//            .universities(new ArrayList<>())
+//            .statusList(new ArrayList<>())
+            .gender(null)
+            .subjects(null)
+            .locations(null)
+            .universities(null)
+            .statusList(null)
+            .build();
+
 
         //when
         Page<TutorSimpleResponseDto> tutorProfileDtos = tutorProfileService.getTutorList(pageable,


### PR DESCRIPTION

### 이 PR을 통해 해결하려는 문제
- 프론트에서 필터링 값을 조회하여 사용할 수 있는 API 생성
- 프론트에서 전달한 문자열 값을 enum 클래스로 변환

### 이 PR에서 변경된 사항

**필터링 값 목록 조회 API**
- 프론트단에서 필터값들을 가져와서 화면에 노출할 때 사용
- TutorProfileController : getFilters() 메서드 추가
- 관련 Enum 클래스에 description 필드 추가( + getter 추가)

**description으로 선택되어 전달받은 데이터를 enum 클래스로 변환하기**
- TutorFilterRequestDto
  - 필드를 String타입으로 변환(ex. List<Subject> -> List<String>)
  - 내부 static class 생성(TutorEnumFilter)
  - 필드별로 converter 메서드 생성
- TutorProfileController :
  - String 필드를 가진 TutorFilterRequestDto를 통해 데이터를 받고 TutorFilterRequestDto.TutorEnumFilter 클래스로 변환하여 서비스 계층으로 전달
  - University, Subject, Gender, Location, EnrollmentStatus 클래스에 description을 enum으로 변환하는 메서드 생성(TutorFilterRequest의 converter에 사용)

### 참고 스크린샷

### 기타

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 -->
- [ ] 테스트 코드
- [x] API 테스트
