### PR TITLE
feat-back-exception-handle 글로벌 예외 핸들러 생성 후 테스트

### DIFF
--- a/backend/src/main/java/com/simzoo/withmedical/controller/SignupController.java
+++ b/backend/src/main/java/com/simzoo/withmedical/controller/SignupController.java
@@ -1,10 +1,11 @@
 package com.simzoo.withmedical.controller;
 
-import com.simzoo.withmedical.dto.member.MemberResponseDto;
 import com.simzoo.withmedical.dto.auth.SignupRequestDto;
+import com.simzoo.withmedical.dto.member.MemberResponseDto;
 import com.simzoo.withmedical.service.MemberService;
 import com.simzoo.withmedical.service.SignupService;
 import com.simzoo.withmedical.service.VerificationService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -23,7 +24,7 @@ public class SignupController {
     private final VerificationService verificationService;
 
     @PostMapping("/signup")
-    public ResponseEntity<MemberResponseDto> signup(@RequestBody SignupRequestDto requestDto) {
+    public ResponseEntity<MemberResponseDto> signup(@Valid @RequestBody SignupRequestDto requestDto) {
 
         return ResponseEntity.ok(signupService.signup(requestDto).toResponseDto());
     }

--- a/backend/src/main/java/com/simzoo/withmedical/dto/exception/CustomErrorResponseDto.java
+++ b/backend/src/main/java/com/simzoo/withmedical/dto/exception/CustomErrorResponseDto.java
@@ -1,0 +1,11 @@
+package com.simzoo.withmedical.dto.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class CustomErrorResponseDto {
+    private String errorCode;
+    private String message;
+}

--- a/backend/src/main/java/com/simzoo/withmedical/dto/exception/NotValidResponseDto.java
+++ b/backend/src/main/java/com/simzoo/withmedical/dto/exception/NotValidResponseDto.java
@@ -1,0 +1,30 @@
+package com.simzoo.withmedical.dto.exception;
+
+import java.util.ArrayList;
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class NotValidResponseDto {
+
+    List<Message> data;
+
+    public NotValidResponseDto() {
+        data = new ArrayList<>();
+    }
+
+    public void addErrorMessage(Message message) {
+        data.add(message);
+    }
+
+    @Builder
+    @Getter
+    public static class Message {
+
+        String field;
+        String message;
+    }
+}

--- a/backend/src/main/java/com/simzoo/withmedical/dto/exception/UnexpectedErrorResponseDto.java
+++ b/backend/src/main/java/com/simzoo/withmedical/dto/exception/UnexpectedErrorResponseDto.java
@@ -1,0 +1,28 @@
+package com.simzoo.withmedical.dto.exception;
+
+import java.time.LocalDateTime;
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class UnexpectedErrorResponseDto {
+    private final String message;      // 에러 메시지
+    private final String errorCode;    // 커스텀 에러 코드 (예: "INTERNAL_SERVER_ERROR")
+    private final int status;          // HTTP 상태 코드 (예: 500)
+    private final LocalDateTime timestamp; // 에러 발생 시간
+    private final String debugId;      // 요청/디버깅 ID (optional)
+
+    public static UnexpectedErrorResponseDto of(
+        String message,
+        String errorCode,
+        int status
+    ) {
+        return UnexpectedErrorResponseDto.builder()
+            .message(message)
+            .errorCode(errorCode)
+            .status(status)
+            .timestamp(LocalDateTime.now())
+            .build();
+    }
+}

--- a/backend/src/main/java/com/simzoo/withmedical/exception/CustomException.java
+++ b/backend/src/main/java/com/simzoo/withmedical/exception/CustomException.java
@@ -8,5 +8,6 @@ public class CustomException extends RuntimeException {
 
     public CustomException(ErrorCode errorCode) {
         super(errorCode.getMessage());
+        this.errorCode = errorCode;
     }
 }

--- a/backend/src/main/java/com/simzoo/withmedical/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/simzoo/withmedical/exception/GlobalExceptionHandler.java
@@ -1,0 +1,84 @@
+package com.simzoo.withmedical.exception;
+
+import com.simzoo.withmedical.dto.exception.CustomErrorResponseDto;
+import com.simzoo.withmedical.dto.exception.NotValidResponseDto;
+import com.simzoo.withmedical.dto.exception.UnexpectedErrorResponseDto;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.FieldError;
+import org.springframework.validation.ObjectError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    // @Valid 검증에서 실패했을 때 예외 처리
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<NotValidResponseDto> handleNotValidException(
+        MethodArgumentNotValidException e) {
+        BindingResult bindingResult = e.getBindingResult();
+
+        NotValidResponseDto response = new NotValidResponseDto();
+
+        for (FieldError fieldError : bindingResult.getFieldErrors()) {
+            response.addErrorMessage(NotValidResponseDto.Message.builder()
+                .message(fieldError.getDefaultMessage())
+                .field("Invalid value for field: " + fieldError.getField())
+                .build());
+        }
+
+        // 클래스 레벨 에러 처리
+        for (ObjectError globalError : bindingResult.getGlobalErrors()) {
+            response.addErrorMessage(NotValidResponseDto.Message.builder()
+                .message(globalError.getDefaultMessage())
+                .field("Invalid value for field: " + globalError.getObjectName())
+                .build());
+        }
+
+        return ResponseEntity
+            .status(HttpStatus.BAD_REQUEST)
+            .body(response);
+    }
+
+    // CustomException 예외 처리 핸들러
+    @ExceptionHandler(CustomException.class)
+    public ResponseEntity<CustomErrorResponseDto> handleCustomException(CustomException ex) {
+        log.error("CustomException handled: {}", ex.getErrorCode());
+
+        ErrorCode errorCode = ex.getErrorCode();
+        CustomErrorResponseDto errorResponse = new CustomErrorResponseDto(
+            errorCode.name(),
+            errorCode.getMessage()
+        );
+        return ResponseEntity
+            .status(errorCode.getHttpStatus())
+            .body(errorResponse);
+    }
+
+    // 예기치 않은 모든 예외를 처리하는 핸들러
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<UnexpectedErrorResponseDto> handleUnexpectedException(Exception e) {
+        // 에러 로그를 기록
+        log.error("Unexpected error occurred: {}", e);
+
+        // UnexpectedErrorResponseDto를 통해 클라이언트에게 오류 메시지 반환
+        String message = "서버 내부 오류가 발생했습니다. 관리자에게 문의하세요.";
+        String errorCode = HttpStatus.INTERNAL_SERVER_ERROR.name();
+        int statusCode = HttpStatus.INTERNAL_SERVER_ERROR.value();
+
+        UnexpectedErrorResponseDto response = UnexpectedErrorResponseDto.of(message, errorCode, statusCode);
+
+        // 500 Internal Server Error 상태로 응답을 반환
+        return ResponseEntity
+            .status(HttpStatus.INTERNAL_SERVER_ERROR)
+            .body(response);
+    }
+
+
+}
+

--- a/backend/src/main/java/com/simzoo/withmedical/security/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/com/simzoo/withmedical/security/JwtAuthenticationFilter.java
@@ -13,11 +13,9 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.stereotype.Component;
 import org.springframework.util.ObjectUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 
-@Component
 @RequiredArgsConstructor
 @Slf4j
 public class JwtAuthenticationFilter extends OncePerRequestFilter {

--- a/backend/src/main/java/com/simzoo/withmedical/util/validator/PasswordConfirmValidator.java
+++ b/backend/src/main/java/com/simzoo/withmedical/util/validator/PasswordConfirmValidator.java
@@ -4,7 +4,8 @@ import com.simzoo.withmedical.dto.auth.SignupRequestDto;
 import jakarta.validation.ConstraintValidator;
 import jakarta.validation.ConstraintValidatorContext;
 
-public class PasswordConfirmValidator implements ConstraintValidator<PasswordConfirm, SignupRequestDto> {
+public class PasswordConfirmValidator implements
+    ConstraintValidator<PasswordConfirm, SignupRequestDto> {
 
     @Override
     public void initialize(PasswordConfirm constraintAnnotation) {
@@ -12,6 +13,11 @@ public class PasswordConfirmValidator implements ConstraintValidator<PasswordCon
 
     @Override
     public boolean isValid(SignupRequestDto signupRequestDto, ConstraintValidatorContext context) {
+
+        if (signupRequestDto.getPasswordConfirm() == null
+            || signupRequestDto.getPasswordConfirm().isEmpty()) {
+            return false;
+        }
 
         return signupRequestDto.getPassword().equals(signupRequestDto.getPasswordConfirm());
     }

--- a/backend/src/main/java/com/simzoo/withmedical/util/validator/PasswordValidator.java
+++ b/backend/src/main/java/com/simzoo/withmedical/util/validator/PasswordValidator.java
@@ -15,6 +15,11 @@ public class PasswordValidator implements ConstraintValidator<Password, String> 
 
     @Override
     public boolean isValid(String value, ConstraintValidatorContext context) {
+
+        if (value == null) {
+            return false;
+        }
+
         return Pattern.matches(regexp, value);
     }
 }

--- a/backend/src/main/java/com/simzoo/withmedical/util/validator/PhoneNumberValidator.java
+++ b/backend/src/main/java/com/simzoo/withmedical/util/validator/PhoneNumberValidator.java
@@ -15,6 +15,10 @@ public class PhoneNumberValidator implements ConstraintValidator<PhoneNumber, St
 
     @Override
     public boolean isValid(String s, ConstraintValidatorContext constraintValidatorContext) {
+        if (s == null || s.isEmpty()) {
+            return false;
+        }
+
         return Pattern.matches(regex, s);
     }
 }

--- a/backend/src/main/java/com/simzoo/withmedical/util/validator/ProfileNotNullValidator.java
+++ b/backend/src/main/java/com/simzoo/withmedical/util/validator/ProfileNotNullValidator.java
@@ -14,6 +14,15 @@ public class ProfileNotNullValidator implements ConstraintValidator<ProfileNotNu
 
     @Override
     public boolean isValid(SignupRequestDto requestDto, ConstraintValidatorContext context) {
+
+        boolean isTutorProfileInvalid = Objects.isNull(requestDto.getTutorProfile());
+        boolean isTuteeProfileInvalid = Objects.isNull(requestDto.getTuteeProfile());
+        boolean isTuteeProfilesEmpty = requestDto.getTuteeProfiles() == null || requestDto.getTuteeProfiles().isEmpty();
+
+        if (isTuteeProfileInvalid || isTuteeProfilesEmpty || isTutorProfileInvalid) {
+            return false;
+        }
+
         if (requestDto.getRole() == Role.TUTOR) {
             return !Objects.isNull(requestDto.getTutorProfile());
         } else {

--- a/backend/src/test/java/com/simzoo/withmedical/exception/GlobalExceptionHandlerTest.java
+++ b/backend/src/test/java/com/simzoo/withmedical/exception/GlobalExceptionHandlerTest.java
@@ -1,0 +1,114 @@
+package com.simzoo.withmedical.exception;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.simzoo.withmedical.config.SecurityConfig;
+import com.simzoo.withmedical.controller.SignupController;
+import com.simzoo.withmedical.dto.auth.SignupRequestDto;
+import com.simzoo.withmedical.entity.MemberEntity;
+import com.simzoo.withmedical.service.MemberService;
+import com.simzoo.withmedical.service.SignupService;
+import com.simzoo.withmedical.service.VerificationService;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.validation.BindException;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+
+
+@WebMvcTest(value = SignupController.class, excludeFilters = {
+    @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = SecurityConfig.class)
+})
+@Import({GlobalExceptionHandler.class})
+@AutoConfigureMockMvc(addFilters = false)
+@MockBean(JpaMetamodelMappingContext.class)
+class GlobalExceptionHandlerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private SignupService signupService;
+
+    @MockBean
+    private VerificationService verifyService;
+
+    @MockBean
+    private MemberService memberService;
+
+    @Test
+    void handleNotValidException_ShouldReturnBadRequest() throws Exception {
+        // Given: FieldError 생성
+        FieldError fieldError = new FieldError("objectName", "field", "Invalid field value");
+        BindingResult bindingResult = new BindException(new Object(), "objectName");
+        bindingResult.addError(fieldError);
+
+        MethodArgumentNotValidException exception = new MethodArgumentNotValidException(null,
+            bindingResult);
+
+        SignupRequestDto invalidRequestDto = SignupRequestDto.builder()
+            .nickname("nickname")
+            .gender(null)
+            .imageUrl("image")
+            .build();
+
+        MemberEntity member = new MemberEntity();
+
+        // When: MockMvc 실행
+        ResultActions result = mockMvc.perform(
+            post("/signup")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(invalidRequestDto))
+        );
+
+        System.out.println("result: " + result.andReturn().getResponse().getContentAsString());
+
+        // Then: 응답 검증
+        result.andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void handleCustomException_ShouldReturnCustomError() throws Exception {
+        // Given: 예외를 발생시키는 동작 설정
+        String receivePhone = "010";
+        Integer verifyNumber = 1111;
+
+        // verifyService에서 CustomException 발생 설정
+        Mockito.doThrow(new CustomException(ErrorCode.NOT_FOUND_VERIFY_NUMBER))
+            .when(verifyService).verifyNumber(receivePhone, verifyNumber);
+
+        // When: MockMvc를 사용해 /signup/verify 엔드포인트 호출
+        ResultActions result = mockMvc.perform(
+            post("/signup/verify")
+                .param("receivePhone", receivePhone)
+                .param("verifyNumber", verifyNumber.toString())
+                .contentType(MediaType.APPLICATION_JSON)
+        );
+
+        // Debug: 응답 내용 확인
+        System.out.println("Response: " + result.andReturn().getResponse().getContentAsString());
+
+        // Then: 응답 검증
+        result.andExpect(status().isNotFound()) // 404 상태 확인
+            .andExpect(jsonPath("$.errorCode").value("NOT_FOUND_VERIFY_NUMBER"))
+            .andExpect(jsonPath("$.message").value("인증번호가 존재하지 않거나 만료되었습니다."));
+    }
+}


### PR DESCRIPTION

### 이 PR을 통해 해결하려는 문제

### 이 PR에서 변경된 사항
- GlobalExceptionHandler : Validation 에러, CustomException, 예상치 못한 곳에서 발생한 예외에 대해 예외처리
- 관련 Dto : CustomErrorResponseDto, NotValidResponseDto, UnexpectedErrorResponseDto
- 테스트 과정에서 validation 관련 코드 수정 : PasswordValidator, PasswordConfirmValidator, ProfileNotNullValidator, PhoneNumberValidator 에서 null 처리 로직 추가
- SignupController : RequestBody 앞에 Valid 어노테이션 추가
- CustomException : 생성자 코드 수정 (errorCode 초기화)
- 테스트 : GlobalExceptionHandlerTest

기타
- CustomException 생성자에서 errorCode를 초기화해주지 않아서 GlobalExceptionHandler에서 nullPointerException 발생.

### 참고 스크린샷

### 기타

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 -->
- [ ] 테스트 코드
- [ ] API 테스트
