### PR TITLE
feat-front-signup-openapi 지역, 학교 선택 시 오픈API 사용

### DIFF
--- a/frontend/chat-frontend/src/components/modal/LocationModal.css
+++ b/frontend/chat-frontend/src/components/modal/LocationModal.css
@@ -1,0 +1,90 @@
+.modal-body {
+    display: flex;
+    gap: 20px;
+    padding: 10px 0;
+}
+
+/* 시/도 목록 */
+.sido-list {
+    width: 50%;
+    border-right: 1px solid #ddd;
+    padding-right: 10px;
+}
+
+.sido-list h3 {
+    font-size: 16px;
+    margin-bottom: 10px;
+}
+
+.sigungu-list {
+    width: 50%;
+    padding-left: 10px;
+}
+
+.sigungu-list h3 {
+    font-size: 16px;
+    margin-bottom: 10px;
+}
+
+ul {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    max-height: 200px;
+    overflow-y: auto;
+}
+
+li {
+    padding: 10px;
+    cursor: pointer;
+    border: 1px solid #ddd;
+    margin-bottom: 5px;
+    border-radius: 4px;
+    text-align: center;
+    transition: background-color 0.2s ease;
+}
+
+li:hover {
+    background-color: #f0f0f0;
+}
+
+li.selected {
+    background-color: #007bff;
+    color: white;
+}
+
+.modal-actions {
+    display: flex;
+    justify-content: flex-end;
+    margin-top: 10px;
+}
+
+button {
+    padding: 8px 16px;
+    margin-left: 10px;
+    border: none;
+    border-radius: 4px;
+    font-size: 14px;
+    cursor: pointer;
+    transition: background-color 0.2s ease;
+}
+
+button:hover {
+    opacity: 0.8;
+}
+
+button:nth-child(1) {
+    background-color: #ccc;
+    color: #333;
+}
+
+button:nth-child(2) {
+    background-color: #007bff;
+    color: white;
+}
+
+button[disabled] {
+    background-color: #ddd;
+    color: #aaa;
+    cursor: not-allowed;
+}

--- a/frontend/chat-frontend/src/components/modal/LocationModal.js
+++ b/frontend/chat-frontend/src/components/modal/LocationModal.js
@@ -1,0 +1,112 @@
+import React, { useState, useEffect } from "react";
+import axios from "axios";
+import "./LocationModal.css";
+
+const LocationModal = ({ onClose, onSave }) => {
+    const [sidoList, setSidoList] = useState([]);
+    const [sigunguList, setSigunguList] = useState([]);
+    const [selectedSido, setSelectedSido] = useState(null); // 선택된 시/도
+    const [selectedSigungu, setSelectedSigungu] = useState(null); // 선택된 시/군/구
+
+    useEffect(() => {
+        // Fetch 시도 리스트
+        const fetchSido = async () => {
+            try {
+                const response = await axios.get(`${process.env.REACT_APP_BACKEND_URL}/locations`, {
+                    params: { cd: "", pg_yn: "0" },
+                });
+                setSidoList(response.data.result);
+            } catch (err) {
+                console.error("Failed to fetch 시도 data:", err);
+            }
+        };
+        fetchSido();
+    }, []);
+
+    const fetchSigungu = async (sidoCode) => {
+        try {
+            const response = await axios.get(`${process.env.REACT_APP_BACKEND_URL}/locations`, {
+                params: { cd: sidoCode, pg_yn: "0" },
+            });
+            setSigunguList(response.data.result);
+        } catch (err) {
+            console.error("Failed to fetch 시군구 data:", err);
+        }
+    };
+
+    const handleSidoSelect = (sido) => {
+        setSelectedSido(sido); // 시/도 선택
+        fetchSigungu(sido.cd); // 해당 시/도의 시군구 데이터 로드
+    };
+
+    const handleSigunguSelect = (sigungu) => {
+        setSelectedSigungu(sigungu); // 시/군/구 선택
+    };
+
+    const handleSave = () => {
+        if (!selectedSigungu) {
+            alert("시군구를 선택해주세요!");
+            return;
+        }
+        console.log('sido: ', selectedSido );
+        console.log('sigungu: ', selectedSigungu );
+        onSave({ 
+            sido: selectedSido,
+            sigungu: selectedSigungu
+         }); // 선택한 지역 전달
+        onClose();
+    };
+
+    return (
+        <div className="modal-overlay">
+            <div className="modal-content">
+                <h2>지역 선택</h2>
+                <div className="modal-body">
+                    {/* 시/도 목록 */}
+                    <div className="sido-list">
+                        <h3>시/도</h3>
+                        <ul>
+                            {sidoList.map((sido) => (
+                                <li
+                                    key={sido.cd}
+                                    onClick={() => handleSidoSelect(sido)}
+                                    className={selectedSido?.cd === sido.cd ? "selected" : ""}
+                                >
+                                    {sido.addr_name}
+                                </li>
+                            ))}
+                        </ul>
+                    </div>
+
+                    {/* 시군구 목록 */}
+                    <div className="sigungu-list">
+                        <h3>시/군/구</h3>
+                        {selectedSido ? (
+                            <ul>
+                                {sigunguList.map((sigungu) => (
+                                    <li
+                                        key={sigungu.cd}
+                                        onClick={() => handleSigunguSelect(sigungu)}
+                                        className={selectedSigungu?.cd === sigungu.cd ? "selected" : ""}
+                                    >
+                                        {sigungu.addr_name}
+                                    </li>
+                                ))}
+                            </ul>
+                        ) : (
+                            <p>시/도를 먼저 선택해주세요.</p>
+                        )}
+                    </div>
+                </div>
+                <div className="modal-actions">
+                    <button onClick={onClose}>취소</button>
+                    <button onClick={handleSave} disabled={!selectedSigungu}>
+                        저장
+                    </button>
+                </div>
+            </div>
+        </div>
+    );
+};
+
+export default LocationModal;

--- a/frontend/chat-frontend/src/components/modal/SchoolModal.css
+++ b/frontend/chat-frontend/src/components/modal/SchoolModal.css
@@ -1,0 +1,80 @@
+.modal-content {
+    width: 400px;
+    max-height: 600px;
+    background-color: #fff;
+    padding: 20px;
+    border-radius: 8px;
+    display: flex;
+    flex-direction: column;
+    box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+}
+
+.search-bar {
+    display: flex;
+    margin-bottom: 10px;
+}
+
+.search-bar input {
+    flex: 1;
+    padding: 8px;
+    font-size: 14px;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+}
+
+.university-list-container {
+    flex-grow: 1;
+    overflow-y: auto; /* 스크롤 추가 */
+    margin-top: 10px;
+    border-top: 1px solid #eee;
+    padding-top: 10px;
+}
+
+.university-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+}
+
+.university-item {
+    padding: 10px;
+    border-bottom: 1px solid #f0f0f0;
+    cursor: pointer;
+    transition: background-color 0.2s;
+}
+
+.university-item:hover {
+    background-color: #f9f9f9;
+}
+
+.university-name {
+    font-size: 16px;
+    font-weight: bold;
+    margin: 0;
+}
+
+.university-info {
+    font-size: 14px;
+    color: #666;
+    margin: 0;
+}
+
+.modal-actions {
+    margin-top: 10px;
+    text-align: right;
+}
+
+.modal-actions button {
+    padding: 8px 16px;
+    border: none;
+    border-radius: 4px;
+    background-color: #007bff;
+    color: white;
+    font-size: 14px;
+    cursor: pointer;
+    transition: background-color 0.2s;
+}
+
+.modal-actions button:hover {
+    background-color: #0056b3;
+}

--- a/frontend/chat-frontend/src/components/modal/SchoolModal.js
+++ b/frontend/chat-frontend/src/components/modal/SchoolModal.js
@@ -1,0 +1,89 @@
+import React, { useState, useEffect } from "react";
+import axios from "axios";
+import "./SchoolModal.css";
+
+const SchoolModal = ({ onClose, onSave, schoolType }) => {
+    const [searchTerm, setSearchTerm] = useState("");
+    const [schoolList, setSchoolList] = useState([]);
+    const [loading, setLoading] = useState(false);
+    const [error, setError] = useState(null);
+
+    useEffect(() => {
+        const fetchSchools = async () => {
+            if (!searchTerm) {
+                setSchoolList([]); // 검색어가 없을 경우 목록 초기화
+                return;
+            }
+            setLoading(true);
+            setError(null);
+
+            try {
+                const response = await axios.get(`${process.env.REACT_APP_BACKEND_URL}/schools`, {
+                    params: {
+                        schoolName: searchTerm,
+                        thisPage: 1,
+                        perPage: 10,
+                        gubun: schoolType === "university" ? "univ_list" : "school_list", // 학교 유형에 따라 API 파라미터 변경
+                        schoolType1: schoolType === "university" ? "100323" : "100322", // 대학/학교 구분 값 설정
+                        schoolType2: schoolType === "university" ? "100328" : "100329",
+                    },
+                });
+                setSchoolList(response.data.dataSearch?.content || []);
+            } catch (err) {
+                console.error("Failed to fetch schools:", err);
+                setError("학교 정보를 가져오는 데 실패했습니다.");
+            } finally {
+                setLoading(false);
+            }
+        };
+
+        const delayDebounceFn = setTimeout(fetchSchools, 300);
+        return () => clearTimeout(delayDebounceFn);
+    }, [searchTerm, schoolType]);
+
+    const handleSelectSchool = (school) => {
+        const selectedSchool = {
+            schoolName: school.schoolName,
+            seq: school.seq,
+        };
+        onSave(selectedSchool); // 부모 컴포넌트로 선택 정보 전달
+        onClose(); // 모달 닫기
+    };
+
+    return (
+        <div className="modal-overlay">
+            <div className="modal-content">
+                <h2>{schoolType === "university" ? "대학 검색" : "학교 검색"}</h2>
+                <div className="search-bar">
+                    <input
+                        type="text"
+                        value={searchTerm}
+                        onChange={(e) => setSearchTerm(e.target.value)}
+                        placeholder={`${schoolType === "university" ? "대학명" : "학교명"}을 입력하세요`}
+                    />
+                </div>
+                {loading && <p>검색 중...</p>}
+                {error && <p className="error">{error}</p>}
+                <div className="school-list-container">
+                    <ul className="school-list">
+                        {schoolList.map((school) => (
+                            <li
+                                key={school.seq}
+                                onClick={() => handleSelectSchool(school)}
+                                className="school-item"
+                            >
+                                <p className="school-name">{school.schoolName}</p>
+                                <p className="school-info">{school.region} - {school.adres}</p>
+                            </li>
+                        ))}
+                    </ul>
+                </div>
+                <div className="modal-actions">
+                    <button onClick={onClose}>취소</button>
+                </div>
+            </div>
+        </div>
+    );
+};
+
+export default SchoolModal;

--- a/frontend/chat-frontend/src/components/signup/Signup.css
+++ b/frontend/chat-frontend/src/components/signup/Signup.css
@@ -75,3 +75,14 @@
     border: 2px solid #007bff;
 }
 
+.button-group {
+    display: flex;
+    justify-content: center;
+    gap: 10px;
+    margin-top: 20px; /* 버튼 간 상단 여백 추가 */
+    position: static; /* 부모 컨테이너 내 정렬 */
+}
+
+.required {
+    color: rgb(230, 97, 97);
+}

--- a/frontend/chat-frontend/src/components/signup/Signup.css
+++ b/frontend/chat-frontend/src/components/signup/Signup.css
@@ -77,12 +77,29 @@
 
 .button-group {
     display: flex;
-    justify-content: center;
-    gap: 10px;
+    justify-content: space-around;
     margin-top: 20px; /* 버튼 간 상단 여백 추가 */
-    position: static; /* 부모 컨테이너 내 정렬 */
+    flex-wrap: wrap;
 }
 
 .required {
     color: rgb(230, 97, 97);
+}
+
+.remove-button {
+    float: right;
+    background-color: #ff4d4f;
+    color: white;
+    border: none;
+    padding: 5px 10px;
+    border-radius: 5px;
+    cursor: pointer;
+}
+
+.remove-button:hover {
+    background-color: #d9363e;
+}
+
+.form-container {
+    width: 100%;
 }

--- a/frontend/chat-frontend/src/components/signup/Signup.js
+++ b/frontend/chat-frontend/src/components/signup/Signup.js
@@ -78,12 +78,193 @@ const Signup = () => {
     const [locations, setLocations] = useState([]); 
     const [universities, setUniversities] = useState([]); 
     const [error, setError] = useState('');
+    const [errors, setErrors] = useState('');
     const navigate = useNavigate();
     const [selectedLocation, setSelectedLocation] = useState(null);
     const [isLocationModalOpen, setIsLocationModalOpen] = useState(false);
     const [isSchoolModalOpen, setIsSchoolModalOpen] = useState(false);
     const [selectedSchool, setSelectedSchool] = useState(null);
     const [schoolType, setSchoolType] = useState("university");
+
+    const phoneRegex = /^\d{2,3}\d{3,4}\d{4}$/;
+    const passwordRegex = /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[@#$%^&+=!]).{8,50}$/;
+
+    const handleChange = (field, value) => {
+        switch (field) {
+            case 'nickname':
+                setNickname(value);
+                setErrors((prev) => ({ ...prev, nickname: value.length >= 2 && value.length <= 20 ? '' : '닉네임은 2~20자 이내여야 합니다.' }));
+                break;
+            case 'phoneNumber':
+                setPhoneNumber(value);
+                setErrors((prev) => ({ ...prev, phoneNumber: phoneRegex.test(value) ? '' : '핸드폰 번호 형식이 올바르지 않습니다.' }));
+                break;
+            case 'password':
+                setPassword(value);
+                setErrors((prev) => ({ ...prev, password: passwordRegex.test(value) ? '' : '비밀번호는 영문, 숫자, 특수문자를 포함해야 합니다.' }));
+                break;
+            case 'passwordConfirm':
+                setPasswordConfirm(value);
+                setErrors((prev) => ({ ...prev, passwordConfirm: value === password ? '' : '비밀번호가 일치하지 않습니다.' }));
+                break;
+            case 'role':
+                setRole(value);
+                setErrors((prev) => ({ ...prev, role: value ? '' : '역할을 선택해주세요.' }));
+                break;
+            default:
+                break;
+        }
+    };
+
+    const handleProfileFieldChange = (field, value, profileType) => {
+        if (profileType === "TUTOR") {
+            setTutorProfile((prev) => ({ ...prev, [field]: value }));
+    
+            // 필수 필드에 대한 검증
+            if (field === "subjects") {
+                setErrors((prev) => ({
+                    ...prev,
+                    subjects: value.length > 0 ? "" : "과목을 1개 이상 선택해주세요."
+                }));
+            }
+            if (field === "location") {
+                setErrors((prev) => ({
+                    ...prev,
+                    location: value ? "" : "지역을 선택해주세요."
+                }));
+            }
+            if (field === "university") {
+                setErrors((prev) => ({
+                    ...prev,
+                    university: value ? "" : "대학 정보를 선택해주세요."
+                }));
+            }
+            if (field === "status") {
+                setErrors((prev) => ({
+                    ...prev,
+                    status: value ? "" : "재학 상태를 선택해주세요."
+                }));
+            }
+        } else if (profileType === "TUTEE") {
+            setTuteeProfile((prev) => ({ ...prev, [field]: value }));
+    
+            // 필수 필드에 대한 검증
+            if (field === "tuteeName") {
+                setErrors((prev) => ({
+                    ...prev,
+                    tuteeName: value ? "" : "이름을 입력해주세요."
+                }));
+            }
+            if (field === "gender") {
+                setErrors((prev) => ({
+                    ...prev,
+                    gender: value ? "" : "성별을 선택해주세요."
+                }));
+            }
+            if (field === "location") {
+                setErrors((prev) => ({
+                    ...prev,
+                    location: value ? "" : "지역을 선택해주세요."
+                }));
+            }
+            if (field === "subjects") {
+                setErrors((prev) => ({
+                    ...prev,
+                    subjects: value.length > 0 ? "" : "과목을 1개 이상 선택해주세요."
+                }));
+            }
+            if (field === "tuteeGrade") {
+                setErrors((prev) => ({
+                    ...prev,
+                    tuteeGrade: value ? "" : "학년을 선택해주세요."
+                }));
+            }
+        } else if (profileType === "PARENT") {
+            setTuteeProfiles((prevProfiles) => {
+                const updatedProfiles = [...prevProfiles]; // 불변성을 유지하며 배열 복사
+                updatedProfiles[currentProfileIndex] = {
+                    ...updatedProfiles[currentProfileIndex], // 현재 인덱스의 프로필 복사
+                    [field]: value, // 변경된 필드만 업데이트
+                };
+                return updatedProfiles; // 업데이트된 배열 반환
+            });
+
+            // 필수 필드에 대한 검증
+            if (field === "tuteeName") {
+                setErrors((prev) => ({
+                    ...prev,
+                    tuteeName: value ? '' : "이름을 입력해주세요."
+                }));
+            }
+            if (field === "gender") {
+                setErrors((prev) => ({
+                    ...prev,
+                    gender: value ? "" : "성별을 선택해주세요."
+                }));
+            }
+            if (field === "location") {
+                setErrors((prev) => ({
+                    ...prev,
+                    location: value ? "" : "지역을 선택해주세요."
+                }));
+            }
+            if (field === "subjects") {
+                setErrors((prev) => ({
+                    ...prev,
+                    subjects: value.length > 0 ? "" : "과목을 1개 이상 선택해주세요."
+                }));
+            }
+            if (field === "tuteeGrade") {
+                setErrors((prev) => ({
+                    ...prev,
+                    tuteeGrade: value ? "" : "학년을 선택해주세요."
+                }));
+            }
+        }
+    };
+
+    const validateStep = () => {
+        const newErrors = {};
+        if (step === 1) {
+            if (!nickname || nickname.length < 2 || nickname.length > 20) newErrors.nickname = "닉네임은 2~20자 이내여야 합니다.";
+            if (!phoneRegex.test(phoneNumber)) newErrors.phoneNumber = "핸드폰 번호 형식이 올바르지 않습니다. (예: 01000000000)";
+        } else if (step === 2) {
+            if (!passwordRegex.test(password)) newErrors.password = "비밀번호는 영문, 숫자, 특수문자를 포함해야 합니다.";
+            if (password !== passwordConfirm) newErrors.passwordConfirm = "비밀번호가 일치하지 않습니다.";
+            if (!role) newErrors.role = "역할을 선택해주세요.";
+        } else if (step === 3) { // Step 3 검증
+            if (role === "TUTOR") {
+                if (!tutorProfile.subjects || tutorProfile.subjects.length === 0)
+                    newErrors.subjects = "과목을 1개 이상 선택해주세요.";
+                if (!tutorProfile.location)
+                    newErrors.location = "지역을 선택해주세요.";
+                if (!tutorProfile.university)
+                    newErrors.university = "대학 정보를 선택해주세요.";
+                if (!tutorProfile.status)
+                    newErrors.status = "재학 상태를 선택해주세요.";
+            } else if (role === "TUTEE") {
+                if (!tuteeProfile.tuteeName)
+                    newErrors.tuteeName = "이름을 입력해주세요.";
+                if (!tuteeProfile.gender)
+                    newErrors.gender = "성별을 선택해주세요.";
+                if (!tuteeProfile.location)
+                    newErrors.location = "지역을 선택해주세요.";
+                if (!tuteeProfile.subjects || tuteeProfile.subjects.length === 0)
+                    newErrors.subjects = "과목을 1개 이상 선택해주세요.";
+                if (!tuteeProfile.tuteeGrade)
+                    newErrors.tuteeGrade = "학년을 선택해주세요.";
+            }
+        }
+        setErrors(newErrors);
+        return Object.keys(newErrors).length === 0;
+    };
+
+
+    const handleNextStep = () => {
+        if (validateStep()) {
+            setStep((prevStep) => prevStep + 1);
+        }
+    };
 
     const handleOpenLocationModal = () => setIsLocationModalOpen(true);
     const handleCloseLocationModal = () => setIsLocationModalOpen(false);
@@ -112,7 +293,7 @@ const Signup = () => {
         setError('');
         try {
             await axios.post(`${process.env.REACT_APP_BACKEND_URL}/auth/login/verify?receivePhone=${phoneNumber}&verifyNumber=${verificationCode}`);
-            nextStep(); // Move to the next step only if validation is successful
+            handleNextStep(); // Move to the next step only if validation is successful
         } catch (err) {
             setError('잘못된 인증번호입니다. 다시 확인해 주세요.');
             console.error(err);
@@ -178,32 +359,31 @@ const Signup = () => {
 
     const handleSignup = async (e) => {
         e.preventDefault();
-        const requestBody = {
-            nickname,
-            gender,
-            phoneNumber,
-            password,
-            passwordConfirm,
-            role,
-            tutorProfile: role === 'TUTOR' ? tutorProfile : null,
-            tuteeProfile: role === 'TUTEE' ? tuteeProfile : null,
-            tuteeProfiles: role === 'PARENT' ? tuteeProfiles : [],
-        };
+        if (validateStep()) {
+            const requestBody = {
+                nickname,
+                gender,
+                phoneNumber,
+                password,
+                passwordConfirm,
+                role,
+                tutorProfile: role === 'TUTOR' ? tutorProfile : null,
+                tuteeProfile: role === 'TUTEE' ? tuteeProfile : null,
+                tuteeProfiles: role === 'PARENT' ? tuteeProfiles : [],
+            };
 
-        console.log(requestBody); // requestBody에서 location 값 확인
+            console.log(requestBody); // requestBody에서 location 값 확인
 
-        try {
-            await axios.post(`${process.env.REACT_APP_BACKEND_URL}/signup`, requestBody);
-            navigate('/login');
-            alert('회원가입이 완료되었습니다!');
-        } catch (error) {
-            console.error(error);
-            setError('회원가입에 실패했습니다. 입력 정보를 확인해주세요.');
+            try {
+                await axios.post(`${process.env.REACT_APP_BACKEND_URL}/signup`, requestBody);
+                navigate('/login');
+                alert('회원가입이 완료되었습니다!');
+            } catch (error) {
+                console.error(error);
+                setError('회원가입에 실패했습니다. 입력 정보를 확인해주세요.');
+            }
         }
     };
-
-    const nextStep = () => setStep((prev) => prev + 1);
-    const prevStep = () => setStep((prev) => prev - 1);
 
     const handleFileChange = async (e, field) => {
         const file = e.target.files[0];
@@ -241,30 +421,48 @@ const Signup = () => {
 
     const handleAddTuteeProfile = () => {
         const currentProfile = tuteeProfiles[currentProfileIndex];
-
-        if (
-            !currentProfile.tuteeName ||
-            !currentProfile.gender ||
-            !currentProfile.location ||
-            currentProfile.subjects.length === 0 ||
-            !currentProfile.tuteeGrade
-        ) {
-            alert('모든 필수 정보를 입력해주세요: 이름, 성별, 지역, 과목, 학년.');
+        const newErrors = {};
+    
+        if (!currentProfile.tuteeName) {
+            newErrors.tuteeName = "이름을 입력해주세요.";
+        }
+        if (!currentProfile.gender) {
+            newErrors.gender = "성별을 선택해주세요.";
+        }
+        if (!currentProfile.location) {
+            newErrors.location = "지역을 선택해주세요.";
+        }
+        if (currentProfile.subjects.length === 0) {
+            newErrors.subjects = "과목을 1개 이상 선택해주세요.";
+        }
+        if (!currentProfile.tuteeGrade) {
+            newErrors.tuteeGrade = "학년을 선택해주세요.";
+        }
+    
+        if (Object.keys(newErrors).length > 0) {
+            // 에러 상태 업데이트
+            setErrors(newErrors);
             return;
         }
-        
-        setTuteeProfiles(
-            [...tuteeProfiles, 
+    
+        // 새로운 학생 프로필 추가
+        setTuteeProfiles([
+            ...tuteeProfiles,
             { 
-                name: '',
+                tuteeName: '',
                 gender: '', 
                 location: '', 
                 subjects: [], 
                 description: '', 
                 tuteeGrade: '' 
-            }]);
+            }
+        ]);
         setCurrentProfileIndex((prevIndex) => prevIndex + 1);
+    
+        // 오류 초기화
+        setErrors({});
     };
+    
 
     const handleProfileChange = (field, value) => {
         // 방어 코드 추가
@@ -364,12 +562,17 @@ const Signup = () => {
             {step === 1 && (
                 <>
                     <div className="input-group">
-                        <label>Nickname</label>
-                        <input type="text" value={nickname} onChange={(e) => setNickname(e.target.value)} required />
+                        <label>닉네임 <span className="required">*</span></label>
+                        <input 
+                            type="text" 
+                            value={nickname} 
+                            onChange={(e) => handleChange('nickname', e.target.value)}     
+                        />
+                        {errors.nickname && <p className="error">{errors.nickname}</p>}
                     </div>
 
                     <div className="input-group">
-                        <label>Gender</label>
+                        <label>성별 <span className="required">*</span></label>
                         <select value={gender} onChange={(e) => setGender(e.target.value)} required>
                             <option value="">Select Gender</option>
                             <option value="MALE">Male</option>
@@ -378,11 +581,16 @@ const Signup = () => {
                     </div>
 
                     <div className="input-group">
-                        <label>Phone Number</label>
-                        <input type="text" value={phoneNumber} onChange={(e) => setPhoneNumber(e.target.value)} required />
+                        <label>핸드폰 번호 <span className="required">*</span></label>
+                        <input 
+                            type="text" 
+                            value={phoneNumber} 
+                            onChange={(e) => handleChange('phoneNumber', e.target.value)} 
+                        />
                         {/* <button type="button" onClick={sendVerificationCode} className="verify-button">인증</button> */}
+                        {errors.phoneNumber && <p className="error">{errors.phoneNumber}</p>}
                     </div>
-                    <button onClick={nextStep}>다음</button>
+                    <button onClick={handleNextStep}>다음</button>
                 </>
             )}
 
@@ -402,26 +610,39 @@ const Signup = () => {
             {step === 2 && (
                 <>
                     <div className="input-group">
-                        <label>Password</label>
-                        <input type="password" value={password} onChange={(e) => setPassword(e.target.value)} required />
+                        <label>비밀번호 <span className="required">*</span></label>
+                        <input 
+                            type="password" 
+                            value={password} 
+                            onChange={(e) => handleChange('password', e.target.value)}
+                        />
+                        {errors.password && <p className="error">{errors.password}</p>}
                     </div>
 
                     <div className="input-group">
-                        <label>Confirm Password</label>
-                        <input type="password" value={passwordConfirm} onChange={(e) => setPasswordConfirm(e.target.value)} required />
+                        <label>비밀번호 확인 <span className="required">*</span></label>
+                        <input 
+                            type="password" 
+                            value={passwordConfirm} 
+                            onChange={(e) => handleChange('passwordConfirm', e.target.value)} 
+                        />
+                        {errors.passwordConfirm && (
+                            <p className="error">{errors.passwordConfirm}</p>
+                        )}
                     </div>
 
                     <div className="input-group">
-                        <label>Role</label>
-                        <select value={role} onChange={(e) => setRole(e.target.value)} required>
+                        <label>역할 <span className="required">*</span></label>
+                        <select value={role} onChange={(e) => handleChange('role', e.target.value)} >
                             <option value="">Select Role</option>
                             <option value="TUTOR">Tutor</option>
                             <option value="TUTEE">Student</option>
                             <option value="PARENT">Parent</option>
                         </select>
+                        {errors.role && <p className='error'>{errors.role}</p>}
                     </div>
-                    <button onClick={prevStep}>이전</button>
-                    <button onClick={nextStep}>다음</button>
+                    <button onClick={() => setStep(1)}>이전</button>
+                    <button onClick={handleNextStep}>다음</button>
                 </>
             )}
 
@@ -452,7 +673,7 @@ const Signup = () => {
                                 />
                             </div>
                             <div className="input-group">
-                                <label>Subjects</label>
+                                <label>과목 <span className="required">*</span></label>
                                 <div className="chip-container">
                                     {subjectsList.map((subject) => (
                                         <div
@@ -464,29 +685,35 @@ const Signup = () => {
                                         </div>
                                     ))}
                                 </div>
+                                {errors.subjects && <p className="error">{errors.subjects}</p>}
                             </div>
                             <div className="input-group">
-                                <label>지역</label>
+                                <label>지역 <span className='required'>*</span></label>
                                 <button onClick={handleOpenLocationModal}>
                                     {tutorProfile.location
                                         ? `${tutorProfile.location.sido.addr_name} > ${tutorProfile.location.sigungu.addr_name}`
                                         : '지역 선택'}
                                 </button>
+                                {errors.location && <p className="error">{errors.location}</p>}
                             </div>
                             <div className="input-group">
-                                <label>대학</label>
+                                <label>대학 <span className='required'>*</span></label>
                                 <button onClick={handleOpenSchoolModal("university")}>
                                     {tutorProfile.university.schoolName || "대학 선택"}
                                 </button>
+                                {errors.university && <p className="error">{errors.university}</p>}
                             </div>
                             <div className="input-group">
-                                <label>Enrollment Status</label>
-                                <select value={tutorProfile.status} onChange={(e) => setTutorProfile({ ...tutorProfile, status: e.target.value })}>
+                                <label>재적 상태 <span className='required'>*</span></label>
+                                <select 
+                                    value={tutorProfile.status} 
+                                    onChange={(e) => handleProfileFieldChange('status', e.target.value, 'TUTOR')}>
                                     <option value="">Select Enrollment Status</option>
                                     {enrollmentStatusList.map((status) => (
                                         <option key={status.value} value={status.value}>{status.label}</option>
                                     ))}
                                 </select>
+                                {errors.status && <p className="error">{errors.status}</p>}
                             </div>
                         </>
                     )}
@@ -494,37 +721,40 @@ const Signup = () => {
                     {role === 'TUTEE' && (
                         <>
                             <div className="input-group">
-                                <label>이름</label>
+                                <label>이름 <span className='required'>*</span></label>
                                 <input
                                     type="text"
                                     value={tuteeProfile.tuteeName}
-                                    onChange={(e) => setTuteeProfile({ ...tuteeProfile, tuteeName: e.target.value })}
+                                    onChange={(e) => handleProfileFieldChange('tuteeName', e.target.value, 'TUTEE')}
                                 />
+                                {errors.tuteeName && <p className="error">{errors.tuteeName}</p>}
                             </div>
 
                             <div className="input-group">
-                                <label>성별</label>
+                                <label>성별 <span className='required'>*</span></label>
                                 <select
                                     value={tuteeProfile.gender}
-                                    onChange={(e) => setTuteeProfile({...tuteeProfile, gender: e.target.value})}
+                                    onChange={(e) => handleProfileFieldChange('gender', e.target.value, 'TUTEE')}
                                 >
                                     <option value="">Select Gender</option>
                                     <option value="MALE">Male</option>
                                     <option value="FEMALE">Female</option>
                                 </select>
+                                {errors.gender && <p className="error">{errors.gender}</p>}
                             </div>
 
                             <div className="input-group">
-                                <label>Location</label>
+                                <label>지역 <span className='required'>*</span></label>
                                 <button onClick={handleOpenLocationModal}>
                                     {tuteeProfile.location
-                                        ? `${tuteeProfile.location.sido.addrName} > ${tuteeProfile.location.sigungu.addrName}`
+                                        ? `${tuteeProfile.location.sido.addr_name} > ${tuteeProfile.location.sigungu.addr_name}`
                                         : '지역 선택'}
                                 </button>
+                                {errors.location && <p className="error">{errors.location}</p>}
                             </div>
                             
                             <div className="input-group">
-                                <label>Subjects</label>
+                                <label>과목 <span className='required'>*</span></label>
                                 <div className="chip-container">
                                     {subjectsList.map((subject) => (
                                         <div
@@ -536,6 +766,7 @@ const Signup = () => {
                                         </div>
                                     ))}
                                 </div>
+                                {errors.subjects && <p className="error">{errors.subjects}</p>}
                             </div>
 
                             <div className="input-group">
@@ -554,47 +785,45 @@ const Signup = () => {
                         </>
                     )}
 
-                    {/* Buttons for TUTOR and TUTEE */}
-                    <div className="button-group">
-                        <button onClick={prevStep}>이전</button>
-                        <button onClick={handleSignup}>회원가입</button>
-                    </div>
                     </>
                     {role === 'PARENT' && (
                         <>
                             <h3>학생 {currentProfileIndex + 1} 프로필</h3>
                             <div className="input-group">
-                                <label>이름</label>
+                                <label>이름 <span className='required'>*</span></label>
                                 <input
                                     type="text"
                                     value={tuteeProfiles[currentProfileIndex]?.tuteeName || ''}
-                                    onChange={(e) => handleProfileChange('tuteeName', e.target.value)} 
+                                    onChange={(e) => handleProfileFieldChange('tuteeName', e.target.value, 'PARENT')}
                                 />
+                                {errors.tuteeName && <p className="error">{errors.tuteeName}</p>}
                             </div>
 
                             <div className="input-group">
-                                <label>성별</label>
+                                <label>성별 <span className='required'>*</span></label>
                                 <select
                                     value={tuteeProfiles[currentProfileIndex]?.gender || ''}
-                                    onChange={(e) => handleProfileChange('gender', e.target.value)}
+                                    onChange={(e) => handleProfileFieldChange('gender', e.target.value, 'PARENT')}
                                 >
                                     <option value="">Select Gender</option>
                                     <option value="MALE">Male</option>
                                     <option value="FEMALE">Female</option>
                                 </select>
+                                {errors.gender && <p className="error">{errors.gender}</p>}
                             </div>
 
                             <div className="input-group">
-                                <label>Location</label>
+                                <label>지역 <span className='required'>*</span></label>
                                 <button onClick={handleOpenLocationModal}>
-                                    {tutorProfile.location
-                                        ? `${tuteeProfiles[currentProfileIndex].location.sido.addrName} > ${tuteeProfiles[currentProfileIndex].location.sigungu.addrName}`
+                                    {tuteeProfiles[currentProfileIndex]?.location
+                                        ? `${tuteeProfiles[currentProfileIndex]?.location.sido.addr_name} > ${tuteeProfiles[currentProfileIndex]?.location.sigungu.addr_name}`
                                         : '지역 선택'}
                                 </button>
+                                {errors.location && <p className="error">{errors.location}</p>}
                             </div>    
 
                             <div className="input-group">
-                                <label>Subjects</label>
+                                <label>과목 <span className='required'>*</span></label>
                                 <div className="chip-container">
                                     {subjectsList.map((subject) => (
                                         <div
@@ -610,13 +839,14 @@ const Signup = () => {
                                         </div>
                                     ))}
                                 </div>
+                                {errors.subject && <p className="error">{errors.subject}</p>}
                             </div>
 
                             <div className="input-group">
-                                <label>Grade</label>
+                                <label>학년 <span className='required'>*</span></label>
                                 <select
                                     value={tuteeProfiles[currentProfileIndex].tuteeGrade}
-                                    onChange={(e) => handleProfileChange('tuteeGrade', e.target.value)}
+                                    onChange={(e) => handleProfileFieldChange('tuteeGrade', e.target.value, 'PARENT')}
                                 >
                                     <option value="">Select Grade</option>
                                     {tuteeGradeList.map((grade) => (
@@ -625,6 +855,7 @@ const Signup = () => {
                                         </option>
                                     ))}
                                 </select>
+                                {errors.tuteeGrade && <p className="error">{errors.tuteeGrade}</p>}
                             </div>
                             <div className="input-group">
                                 <label>소개</label>
@@ -632,18 +863,7 @@ const Signup = () => {
                                     value={tuteeProfiles[currentProfileIndex].description}
                                     onChange={(e) => handleProfileChange('description', e.target.value)}
                                 />
-                            </div>
-                            <div className="button-group">
-                                {currentProfileIndex > 0 ? (
-                                    // 첫 번째 학생 프로필이 아닐 때 이전 프로필로 이동
-                                    <button onClick={handlePreviousProfile}>이전</button>
-                                ) : (
-                                    // 첫 번째 학생 프로필일 때 이전 스텝으로 이동
-                                    <button onClick={prevStep}>이전</button>
-                                )}
-                                <button onClick={handleAddTuteeProfile}>학생 프로필 추가하기</button>
-                                <button onClick={handleSignup}>회원가입</button>
-                            </div>                                          
+                            </div>                                       
                         </>
                     )}
                     {isLocationModalOpen && (
@@ -652,9 +872,23 @@ const Signup = () => {
                     {isSchoolModalOpen && (
                         <SchoolModal onClose={handleCloseSchoolModal} onSave={handleSaveSchool} schoolType={schoolType} />
                     )}
+
+                    <div className="button-group">
+                        {role === 'PARENT' && currentProfileIndex > 0 ? (
+                            // 첫 번째 학생 프로필이 아닐 때 이전 프로필로 이동
+                            <button onClick={handlePreviousProfile}>이전</button>
+                        ) : (
+                            // 첫 번째 학생 프로필일 때 이전 스텝으로 이동
+                            <button onClick={() => setStep(2)}>이전</button>
+                        )}
+                        {role === 'PARENT' && (
+                            <button onClick={handleAddTuteeProfile}>학생 프로필 추가</button>
+                        )}
+                        <button onClick={handleSignup}>회원가입</button>
+                    </div>   
                 </>
                 )}
-                {error && <p className="error">{error}</p>}
+            {errors.server && <p className="error">{errors.server}</p>}
         </div>
     );
 };

--- a/frontend/chat-frontend/src/components/signup/Signup.js
+++ b/frontend/chat-frontend/src/components/signup/Signup.js
@@ -475,11 +475,6 @@ const Signup = () => {
     };
     
     const handleRemoveTuteeProfile = (index) => {
-        if (index === 0) {
-            alert("첫 번째 학생 프로필은 삭제할 수 없습니다.");
-            return;
-        }
-    
         setTuteeProfiles((prevProfiles) => {
             const updatedProfiles = prevProfiles.filter((_, i) => i !== index); // 선택한 프로필 삭제
             return updatedProfiles;


### PR DESCRIPTION
### 이 PR을 통해 해결하려는 문제
- 회원가입 시 지역, 학교 선택에 Open API 사용함에 따라 이에 맞는 모달 생성

### 이 PR에서 변경된 사항
지역 선택, 대학 선택 버튼 선택 시 모달에서 정보 선택 및 저장
- LocationModal.js & css : 지역 선택 모달
- SchoolModal.js & css : 학교 선택
- Signup.js
  - 모달 적용한 회원가입 화면 구현
  - 백엔드에서 요구하는 조건에 맞게 입력을 제한하도록 메세지를 출력하도록 함
  - 수정
    - handleOpenSchoolModal("university") 함수 호출 방식 문제에 따라 무한루프 버그 발생 
    : onClick{handleOpenSchoolModal("university")} -> onClick{() => handleOpenSchoolModal("university")}
- 삭제 버튼 추가 (학부모 회원의 학생프로필이 2개 이상일 때 활성화)
- tutee의 프로필에 성격 입력 항목 추가

### 참고 스크린샷

### 기타

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 -->
- [ ] 테스트 코드
- [x] API 테스트
