### PR TITLE
fix-back-signup-request&openapi

### DIFF
--- a/backend/src/main/java/com/simzoo/withmedical/dto/auth/SignupRequestDto.java
+++ b/backend/src/main/java/com/simzoo/withmedical/dto/auth/SignupRequestDto.java
@@ -10,6 +10,7 @@ import com.simzoo.withmedical.util.validator.Password;
 import com.simzoo.withmedical.util.validator.PasswordConfirm;
 import com.simzoo.withmedical.util.validator.PhoneNumber;
 import com.simzoo.withmedical.util.validator.ProfileNotNull;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
@@ -49,8 +50,11 @@ public class SignupRequestDto {
     private String passwordConfirm;
     private Role role;
 
+    @Valid
     private TutorProfileRequestDto tutorProfile;
+    @Valid
     private TuteeProfileRequestDto tuteeProfile;
+    @Valid
     private List<TuteeProfileRequestDto> tuteeProfiles = new ArrayList<>();
 
     public MemberEntity toMemberEntity(PasswordEncoder passwordEncoder) {

--- a/backend/src/main/java/com/simzoo/withmedical/dto/tutee/TuteeProfileResponseDto.java
+++ b/backend/src/main/java/com/simzoo/withmedical/dto/tutee/TuteeProfileResponseDto.java
@@ -18,6 +18,7 @@ public class TuteeProfileResponseDto {
     private List<Subject> subjects = new ArrayList<>();
     private String location;
     private TuteeGrade tuteeGrade;
+    private String personality;
     private String description;
 
 }

--- a/backend/src/main/java/com/simzoo/withmedical/dto/tutor/TutorProfileRequestDto.java
+++ b/backend/src/main/java/com/simzoo/withmedical/dto/tutor/TutorProfileRequestDto.java
@@ -6,6 +6,8 @@ import com.simzoo.withmedical.entity.MemberEntity;
 import com.simzoo.withmedical.entity.TutorProfileEntity;
 import com.simzoo.withmedical.enums.EnrollmentStatus;
 import com.simzoo.withmedical.enums.Subject;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.Builder;
@@ -15,10 +17,15 @@ import lombok.Getter;
 @Builder
 public class TutorProfileRequestDto {
     private String imageUrl;
+    @NotNull
+    @NotEmpty
     private List<Subject> subjects;
+    @NotNull
     private LocationDto location;
     private String description;
+    @NotNull
     private SchoolDto university;
+    @NotNull
     private EnrollmentStatus status;
 
     public TutorProfileEntity toEntity(MemberEntity member) {

--- a/backend/src/main/java/com/simzoo/withmedical/entity/TuteeProfileEntity.java
+++ b/backend/src/main/java/com/simzoo/withmedical/entity/TuteeProfileEntity.java
@@ -86,6 +86,7 @@ public class TuteeProfileEntity extends BaseEntity {
             .location(location)
             .subjects(subjects.stream().map(SubjectEntity::getSubject).toList())
             .tuteeGrade(grade)
+            .personality(personality)
             .description(description)
             .build();
     }

--- a/backend/src/main/java/com/simzoo/withmedical/util/validator/PhoneNumber.java
+++ b/backend/src/main/java/com/simzoo/withmedical/util/validator/PhoneNumber.java
@@ -11,8 +11,8 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 @Constraint(validatedBy = {PhoneNumberValidator.class})
 public @interface PhoneNumber {
-    String message() default "핸드폰 번호 양식에 맞지 않습니다. ex) 010-0000-0000";
-    String regexp() default "^\\d{2,3}-\\d{3,4}-\\d{4}$";
+    String message() default "핸드폰 번호 양식에 맞지 않습니다. ex) 01000000000";
+    String regexp() default "^\\d{2,3}\\d{3,4}\\d{4}$";
 
     Class<?>[] groups() default { };
 

--- a/backend/src/main/java/com/simzoo/withmedical/util/validator/ProfileNotNullValidator.java
+++ b/backend/src/main/java/com/simzoo/withmedical/util/validator/ProfileNotNullValidator.java
@@ -6,7 +6,8 @@ import jakarta.validation.ConstraintValidator;
 import jakarta.validation.ConstraintValidatorContext;
 import java.util.Objects;
 
-public class ProfileNotNullValidator implements ConstraintValidator<ProfileNotNull, SignupRequestDto>{
+public class ProfileNotNullValidator implements
+    ConstraintValidator<ProfileNotNull, SignupRequestDto> {
 
     @Override
     public void initialize(ProfileNotNull constraintAnnotation) {
@@ -17,16 +18,23 @@ public class ProfileNotNullValidator implements ConstraintValidator<ProfileNotNu
 
         boolean isTutorProfileInvalid = Objects.isNull(requestDto.getTutorProfile());
         boolean isTuteeProfileInvalid = Objects.isNull(requestDto.getTuteeProfile());
-        boolean isTuteeProfilesEmpty = requestDto.getTuteeProfiles() == null || requestDto.getTuteeProfiles().isEmpty();
+        boolean isTuteeProfilesEmpty =
+            requestDto.getTuteeProfiles() == null || requestDto.getTuteeProfiles().isEmpty();
 
-        if (isTuteeProfileInvalid || isTuteeProfilesEmpty || isTutorProfileInvalid) {
+        boolean isTutorProfileValid = !isTutorProfileInvalid;
+        boolean isTuteeProfileValid = !isTuteeProfileInvalid;
+        boolean isTuteeProfilesNotEmpty = !isTuteeProfilesEmpty;
+
+        if (isTuteeProfileInvalid && isTuteeProfilesEmpty && isTutorProfileInvalid) {
             return false;
         }
 
         if (requestDto.getRole() == Role.TUTOR) {
-            return !Objects.isNull(requestDto.getTutorProfile());
+            return isTutorProfileValid;
+        } else if (requestDto.getRole() == Role.TUTEE) {
+            return isTuteeProfileValid;
         } else {
-            return !Objects.isNull(requestDto.getTuteeProfile());
+            return isTuteeProfilesNotEmpty;
         }
     }
 }


### PR DESCRIPTION

### 이 PR을 통해 해결하려는 문제
- SGIS API AccessToken 유효기간 관리 오류 수정
- validation 누락 및 오류 부분 수정
- tuteeprofile에 personality 속성 추가

### 이 PR에서 변경된 사항
sgis 토큰 만료시간 설정 오류
- 절대시각인 timeout의 단위와 현재시간 단위를 맞추지 못해 원하는 시간(4시간)을 TTL로 설정하는 데 실패 : SgisTokenManager.java 현재시간을 ms 단위로 변환하여 계산 후 TTL 을 ms 단위로 설정

validation 관련 오류 및 누락 부분 수정
- 회원가입 시 사용하는 프로필 requestDto에도 validation 적용 : SignupRequestDto
- TutorProfileRequestDto : validation 설정
- PhoneNumber : 메세지, 정규식 수정 (010-0000-0000 -> 01000000000)
- ProfileNotNullValidator
  - 세 프로필 모두 누락될 경우에 대해 false 반환되도록 식 변경 (        if (isTuteeProfileInvalid || isTuteeProfilesEmpty || isTutorProfileInvalid) {
 ->         if (isTuteeProfileInvalid && isTuteeProfilesEmpty && isTutorProfileInvalid) {
)
  - 각 역할에 따라 Null 또는 빈 값이 되면 안 되는 부분에 대해 false 반환하도록 설정(parent 부분 누락되어 추가 + 리펙토링)

 누락된 속성 추가
- personality 필드 추가 : TuteeProfileEntity, TuteeProfileResponseDto,

### 참고 스크린샷

### 기타

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 -->
- [ ] 테스트 코드
- [ ] API 테스트
