### PR TITLE
feat-front-tuteepost-sort 학생 게시물 정렬 버튼 수정

### DIFF
--- a/frontend/chat-frontend/src/components/button/BackButton.css
+++ b/frontend/chat-frontend/src/components/button/BackButton.css
@@ -1,0 +1,15 @@
+.back-button {
+    padding: 10px 20px;
+    background-color: #6c757d;
+    color: white;
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 14px;
+    font-weight: 500;
+    transition: background-color 0.3s ease;
+}
+
+.back-button:hover {
+    background-color: #5a6268;
+}

--- a/frontend/chat-frontend/src/components/button/BackButton.js
+++ b/frontend/chat-frontend/src/components/button/BackButton.js
@@ -1,0 +1,15 @@
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+import './BackButton.css'; // 스타일 파일
+
+const BackButton = ({ label = '돌아가기', className = '' }) => {
+    const navigate = useNavigate();
+
+    return (
+        <button onClick={() => navigate(-1)} className={`back-button ${className}`}>
+            {label}
+        </button>
+    );
+};
+
+export default BackButton;

--- a/frontend/chat-frontend/src/components/button/SortButtonGroup.css
+++ b/frontend/chat-frontend/src/components/button/SortButtonGroup.css
@@ -1,0 +1,36 @@
+.sort-criteria-group {
+    margin-bottom: 20px;
+}
+
+.sort-criteria-row {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    margin-bottom: 10px;
+}
+
+.sort-select,
+.direction-select {
+    padding: 8px 12px;
+    font-size: 14px;
+    border: 1px solid #ddd;
+    border-radius: 4px;
+    cursor: pointer;
+}
+
+.add-criteria-button,
+.remove-criteria-button {
+    padding: 8px 12px;
+    font-size: 14px;
+    background-color: #007bff;
+    color: white;
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+    transition: background-color 0.3s ease;
+}
+
+.add-criteria-button:hover,
+.remove-criteria-button:hover {
+    background-color: #0056b3;
+}

--- a/frontend/chat-frontend/src/components/button/SortButtonGroup.js
+++ b/frontend/chat-frontend/src/components/button/SortButtonGroup.js
@@ -1,0 +1,71 @@
+import React from 'react';
+import './SortButtonGroup.css';
+
+const SortButtonGroup = ({ 
+     sortCriteria,
+     onAddCriteria, 
+     onRemoveCriteria, 
+     onUpdateCriteria,
+     maxCriteria = 3 // 최대 정렬 기준 개수 기본값
+    }) => {
+    const sortOptions = [
+        { value: 'CREATED_AT', label: '게시일' },
+        { value: 'FEE', label: '수업료' },
+        { value: 'TUTEE_GRADE', label: '학년' },
+    ];
+
+    const directionOptions = [
+        { value: 'ASC', label: '오름차순' },
+        { value: 'DESC', label: '내림차순' },
+    ];
+
+    return (
+        <div className="sort-criteria-group">
+            <h3>정렬 기준</h3>
+            {sortCriteria.map((criterion, index) => (
+                <div key={index} className="sort-criteria-row">
+                    <select
+                        value={criterion.key}
+                        onChange={(e) =>
+                            onUpdateCriteria(index, { ...criterion, key: e.target.value })
+                        }
+                        className="sort-select"
+                    >
+                        <option value="">정렬 기준 선택</option>
+                        {sortOptions.map((option) => (
+                            <option key={option.value} value={option.value}>
+                                {option.label}
+                            </option>
+                        ))}
+                    </select>
+                    <select
+                        value={criterion.direction}
+                        onChange={(e) =>
+                            onUpdateCriteria(index, { ...criterion, direction: e.target.value })
+                        }
+                        className="direction-select"
+                    >
+                        {directionOptions.map((option) => (
+                            <option key={option.value} value={option.value}>
+                                {option.label}
+                            </option>
+                        ))}
+                    </select>
+                    <button
+                        onClick={() => onRemoveCriteria(index)}
+                        className="remove-criteria-button"
+                    >
+                        삭제
+                    </button>
+                </div>
+            ))}
+            {sortCriteria.length < maxCriteria && (
+                <button onClick={onAddCriteria} className="add-criteria-button">
+                    기준 추가
+                </button>
+            )}
+        </div>
+    );
+};
+
+export default SortButtonGroup;

--- a/frontend/chat-frontend/src/components/tuteePost/TuteePost.css
+++ b/frontend/chat-frontend/src/components/tuteePost/TuteePost.css
@@ -14,15 +14,6 @@
     transition: background-color 0.3s;
 }
 
-/* 돌아가기 버튼 스타일 */
-.back-button {
-    background-color: #6c757d;
-}
-
-.back-button:hover {
-    background-color: #5a6268;
-}
-
 /* 문의하기 버튼 스타일 */
 .inquiry-button {
     background-color: #007bff;

--- a/frontend/chat-frontend/src/components/tuteePost/TuteePost.js
+++ b/frontend/chat-frontend/src/components/tuteePost/TuteePost.js
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import InquiryButton from '../button/InquiryButton';
 import axios from '../axios/AxiosInstance';
+import BackButton from '../button/BackButton';
 import './TuteePost.css';
 
 const TuteePost = () => {
@@ -63,9 +64,7 @@ const TuteePost = () => {
                 <p><strong>수정일:</strong> {new Date(postDetails.updatedAt).toLocaleDateString()}</p>
             </div>
             <div className="post-actions">
-                <button onClick={() => navigate(-1)} className="back-button">
-                    돌아가기
-                </button>
+                 <BackButton />
                 <InquiryButton
                     recipientId={postDetails.memberId}
                     memberNickname={postDetails.memberNickname}

--- a/frontend/chat-frontend/src/components/tuteePost/TuteePostList.js
+++ b/frontend/chat-frontend/src/components/tuteePost/TuteePostList.js
@@ -4,6 +4,7 @@ import axios from 'axios';
 import qs from 'qs'; 
 import axiosInstance from '../axios/AxiosInstance';
 import InquiryButton from '../button/InquiryButton';
+import SortButtonGroup from '../button/SortButtonGroup';
 import './TuteePostList.css';
 import { Link } from 'react-router-dom';
 
@@ -13,8 +14,7 @@ const TuteePostList = ({ memberId, memberRole }) => {
     const pageSize = 10;
     const maxPageDisplay = 10;
     const [totalPages, setTotalPages] = useState(0); // API로 받은 총 페이지 수 저장
-    const [sortCriteria, setSortCriteria] = useState([]);
-    const [sortDirections, setSortDirection] = useState([]);
+    const [sortCriteria, setSortCriteria] = useState([{ key: 'CREATED_AT', direction: 'DESC' }]);
     const [filters, setFilters] = useState({
         gender: '',
         tuteeGradeType: '',
@@ -30,8 +30,8 @@ const TuteePostList = ({ memberId, memberRole }) => {
                     `${process.env.REACT_APP_BACKEND_URL}/tutee/postings`,
                     {
                         params: {
-                            sortBy: [sortCriteria],
-                            sortDirection: sortDirections,
+                            sortBy: sortCriteria.map((criterion) => criterion.key),
+                            sortDirection: sortCriteria.map((criterion) => criterion.direction),
                             gender: filters.gender || null,
                             tuteeGradeType: filters.tuteeGradeType || null,
                             tutoringType: filters.tutoringType || null,
@@ -51,24 +51,25 @@ const TuteePostList = ({ memberId, memberRole }) => {
         };
 
         fetchPostings();
-    }, [currentPage, sortCriteria, sortDirections, filters]);
+    }, [currentPage, sortCriteria, filters]);
 
     // 필터 값 변경
     const handleFilterChange = (filterName, value) => {
         setFilters((prevFilters) => ({ ...prevFilters, [filterName]: value }));
     };
 
-    // 정렬 기준 변경
-    const handleSortChange = (event) => {
-        const selectedValue = event.target.value;
-        setSortCriteria((prev) =>
-            prev.includes(selectedValue) ? prev.filter((v) => v !== selectedValue) : [...prev, selectedValue]
-        );
+    const handleAddCriteria = () => {
+        setSortCriteria((prev) => [...prev, { key: '', direction: 'DESC' }]);
     };
-    
 
-    const handleSortDirectionChange = (event) => {
-        setSortDirection(event.target.value);
+    const handleRemoveCriteria = (index) => {
+        setSortCriteria((prev) => prev.filter((_, i) => i !== index));
+    };
+
+    const handleUpdateCriteria = (index, updatedCriterion) => {
+        setSortCriteria((prev) =>
+            prev.map((criterion, i) => (i === index ? updatedCriterion : criterion))
+        );
     };
 
     // 페이지 변경
@@ -108,55 +109,17 @@ const TuteePostList = ({ memberId, memberRole }) => {
 
     return (
         <div className="tutee-post-list-container">
+            <SortButtonGroup
+                sortCriteria={sortCriteria}
+                onAddCriteria={handleAddCriteria}
+                onRemoveCriteria={handleRemoveCriteria}
+                onUpdateCriteria={handleUpdateCriteria}
+            />
             <div className="title-container">
                 <h1 className="tutee-post-list-title">학생 목록</h1>
                 {memberRole === 'TUTEE' && (
                     <Link to="/posting-form" className="create-post-button">과외 구인 글 작성하기</Link>
                 )}
-            </div>
-            <div className='sorting-container'>
-                <h3>정렬 기준</h3>
-                <div className='sort-group'>
-                    <label>
-                        <input
-                            type="checkbox"
-                            value="CREATED_AT"
-                            onChange={handleSortChange}
-                            checked={sortCriteria.includes("CREATED_AT")}
-                        />
-                        최신순
-                    </label>
-                    <label>
-                        <input
-                            type="checkbox"
-                            value="FEE"
-                            onChange={handleSortChange}
-                            checked={sortCriteria.includes("FEE")}
-                        />
-                        수업료순
-                    </label>
-                    <label>
-                        <input
-                            type="checkbox"
-                            value="TUTEE_GRADE"
-                            onChange={handleSortChange}
-                            checked={sortCriteria.includes("TUTEE_GRADE")}
-                        />
-                        학년순
-                    </label>
-                </div>
-                {sortCriteria.map((criterion, index) => (
-                    <div key={criterion}>
-                        <label>{criterion}</label>
-                        <select
-                            value={sortDirections[index] || "DESC"}
-                            onChange={(e) => handleSortDirectionChange(e, criterion)}
-                        >
-                            <option value="DESC">내림차순</option>
-                            <option value="ASC">오름차순</option>
-                        </select>
-                    </div>
-                ))}
             </div>
             <div className='filters-container'>
                 <h3>필터</h3>

--- a/frontend/chat-frontend/src/components/tutor/TutorProfile.js
+++ b/frontend/chat-frontend/src/components/tutor/TutorProfile.js
@@ -1,10 +1,10 @@
-// TutorProfile.js
 import React, { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import axios from '../axios/AxiosInstance';
 import Review from '../review/Review';
 import InquiryButton from '../button/InquiryButton';
 import './TutorProfile.css';
+import BackButton from '../button/BackButton';
 
 const TutorProfile = () => {
     const { tutorId } = useParams();
@@ -53,8 +53,8 @@ const TutorProfile = () => {
             <p>등록 상태: {profile.status}</p>
             <p>소개: {profile.description}</p>
 
-            {/* 리뷰 버튼 */}
             <div className='button-row'>
+                <BackButton />
                 <button
                     className="review-toggle-button"
                     onClick={toggleShowReviews}


### PR DESCRIPTION

### 이 PR을 통해 해결하려는 문제
- 학생 게시물 목록 조회 시 사용하는 정렬 버튼 UI/UX 개선
- 돌아가기 버튼 사용(TutorProfile, TuteePost)

### 이 PR에서 변경된 사항
- SortButtonGroup.js & css : 정렬 버튼 컴포넌트
- TuteePostList.js & css: 정렬 버튼 컴포넌트 적용

+ 돌아가기 버튼 사용
- BackButton.js
- TuteePost, TutorProfile에 적용


### 참고 스크린샷

### 기타

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 -->
- [ ] 테스트 코드
- [ ] API 테스트
