### PR TITLE
feat-back-chatroom-roomcheck 채팅방 존재여부 확인 api + 채팅방생성 컨트롤러 로직 수정

### DIFF
--- a/backend/src/main/java/com/simzoo/withmedical/dto/chat/ChatRoomExistDto.java
+++ b/backend/src/main/java/com/simzoo/withmedical/dto/chat/ChatRoomExistDto.java
@@ -1,0 +1,16 @@
+package com.simzoo.withmedical.dto.chat;
+
+import com.querydsl.core.annotations.QueryProjection;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ChatRoomExistDto {
+    private Long roomId;
+
+    @QueryProjection
+    public ChatRoomExistDto(Long roomId) {
+        this.roomId = roomId;
+    }
+}

--- a/backend/src/main/java/com/simzoo/withmedical/repository/chat/room/ChatRoomRepositoryCustom.java
+++ b/backend/src/main/java/com/simzoo/withmedical/repository/chat/room/ChatRoomRepositoryCustom.java
@@ -1,7 +1,7 @@
 package com.simzoo.withmedical.repository.chat.room;
 
+import com.simzoo.withmedical.dto.chat.ChatRoomExistDto;
 import com.simzoo.withmedical.dto.chat.ChatRoomSimpleResponseDto;
-import com.simzoo.withmedical.entity.chat.ChatRoomEntity;
 import com.simzoo.withmedical.enums.filter.ChatRoomFilterType;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
@@ -12,5 +12,5 @@ public interface ChatRoomRepositoryCustom {
     Page<ChatRoomSimpleResponseDto> findAllChatRoomsCreatedByMe(Long userId,
         ChatRoomFilterType filterTp, Pageable pageable);
 
-    Optional<ChatRoomEntity> findByIdWithMember(Long id, Long userId);
+    Optional<ChatRoomExistDto> findByTwoMember(Long member1, Long member2);
 }

--- a/backend/src/test/java/com/simzoo/withmedical/repository/chat/room/ChatRoomRepositoryCustomImplTest.java
+++ b/backend/src/test/java/com/simzoo/withmedical/repository/chat/room/ChatRoomRepositoryCustomImplTest.java
@@ -1,0 +1,139 @@
+package com.simzoo.withmedical.repository.chat.room;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import com.simzoo.withmedical.config.QueryDslConfig;
+import com.simzoo.withmedical.dto.chat.ChatRoomExistDto;
+import com.simzoo.withmedical.entity.MemberEntity;
+import com.simzoo.withmedical.entity.SubjectEntity;
+import com.simzoo.withmedical.entity.TuteeProfileEntity;
+import com.simzoo.withmedical.entity.TutorProfileEntity;
+import com.simzoo.withmedical.entity.chat.ChatRoomEntity;
+import com.simzoo.withmedical.entity.chat.ChatRoomMember;
+import com.simzoo.withmedical.enums.EnrollmentStatus;
+import com.simzoo.withmedical.enums.Gender;
+import com.simzoo.withmedical.enums.Role;
+import com.simzoo.withmedical.enums.Subject;
+import com.simzoo.withmedical.repository.TuteeProfileRepository;
+import com.simzoo.withmedical.repository.member.MemberRepository;
+import com.simzoo.withmedical.repository.subject.SubjectRepository;
+import com.simzoo.withmedical.repository.tutor.TutorProfileRepository;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+@DataJpaTest
+@ActiveProfiles("test")
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Import(QueryDslConfig.class)
+class ChatRoomRepositoryCustomImplTest {
+
+    @Autowired
+    private ChatRoomRepository chatRoomRepository;
+
+    @Autowired
+    private SubjectRepository subjectRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private TutorProfileRepository tutorProfileRepository;
+
+    @Autowired
+    private TuteeProfileRepository tuteeProfileRepository;
+    @Autowired
+    private ChatRoomMemberRepository chatRoomMemberRepository;
+
+    @Test
+    @Transactional
+    void findByTwoMember() {
+        //저장
+        MemberEntity member1 = MemberEntity.builder()
+            .nickname("nickname1")
+            .gender(Gender.MALE)
+            .tutorProfile(null)
+            .roles(List.of(Role.TUTOR))
+            .build();
+
+        MemberEntity member2 = MemberEntity.builder()
+            .nickname("nickname2")
+            .gender(Gender.MALE)
+            .tutorProfile(null)
+            .roles(List.of(Role.TUTEE))
+            .build();
+
+        List<MemberEntity> memberList = List.of(member1, member2);
+        memberRepository.saveAll(memberList);
+
+        TutorProfileEntity tutor1 = TutorProfileEntity.builder()
+            .member(member1)
+            .location("서울특별시 강남구")
+            .univName("고려대학교")
+            .status(EnrollmentStatus.ENROLLED)
+            .subjects(new ArrayList<>())
+            .build();
+
+        member1.saveTutorProfile(tutor1, Role.TUTOR);
+
+        TuteeProfileEntity tutee1 = TuteeProfileEntity.builder()
+            .member(member2)
+            .location("인천광역시 연수구")
+            .gender(Gender.MALE)
+            .subjects(new ArrayList<>())
+            .build();
+
+        member2.saveTuteeProfiles(List.of(tutee1), Role.TUTEE);
+
+        tutorProfileRepository.save(tutor1);
+        tuteeProfileRepository.save(tutee1);
+
+        List<SubjectEntity> subjectEntities1 = List.of(
+            SubjectEntity.builder().tutorProfile(tutor1).subject(Subject.ELEMENTARY_ENGLISH)
+                .build(),
+            SubjectEntity.builder().tutorProfile(tutor1).subject(Subject.MIDDLE_ENGLISH).build()
+        );
+
+        List<SubjectEntity> subjectEntities2 = List.of(SubjectEntity.builder().tuteeProfile(tutee1)
+            .subject(Subject.MIDDLE_ENGLISH).build());
+
+        subjectRepository.saveAll(subjectEntities1);
+        subjectRepository.saveAll(subjectEntities2);
+
+        tutor1.addSubjects(subjectEntities1);
+        tutee1.addSubject(subjectEntities2);
+
+        ChatRoomEntity chatRoom = ChatRoomEntity.builder()
+            .title("title")
+            .build();
+
+        chatRoomRepository.save(chatRoom);
+
+        ChatRoomMember chatRoomMember = ChatRoomMember.builder()
+            .chatRoom(chatRoom)
+            .member(member1)
+            .build();
+
+        ChatRoomMember chatRoomMember2 = ChatRoomMember.builder()
+            .chatRoom(chatRoom)
+            .member(member2)
+            .build();
+
+        chatRoomMemberRepository.save(chatRoomMember);
+        chatRoomMemberRepository.save(chatRoomMember2);
+
+        //when
+        Optional<ChatRoomExistDto> result = chatRoomRepository.findByTwoMember(member1.getId(),
+            member2.getId());
+
+        //then
+        assertNotNull(result);
+    }
+}


### PR DESCRIPTION
### 이 PR을 통해 해결하려는 문제
- 채팅방 생성 전 두 사용자의 채팅방이 이미 있는지 확인한다
- 컨트롤러 코드 리팩토링

### 이 PR에서 변경된 사항
채팅방생성 컨트롤러 로직 수정
- ChatController
  - 채팅방 생성, 첫 채팅 메시지 전송 로직을 하나로 통합
  - 기존 생성된 채팅방이 있는지 확인하는 API 생성 (/chatroom/exist)
- ChatRoomRepositoryCustomImpl
  - ChatRoomExistDto 반환
  - groupBy, having count, distinct 함수 사용
- ChatRoomExistDto : 채팅방 존재 여부 응답을 위한 내용

테스트
- ChatRoomRepositoryCustomImplTest : 쿼리 정상동작여부 체크

### 참고 스크린샷

### 기타

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 -->
- [x] 테스트 코드
- [x] API 테스트
